### PR TITLE
feat(gmail): draft-only Gmail integration with opt-in read scope + setup form + CLI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ bun.lock
 .agents/
 .junie/
 .claude/settings.local.json
+.claude/scheduled_tasks.lock
 
 # Playwright E2E
 /.e2e-maket

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,26 @@ from the git log since the last tag — paste into `[Unreleased]` and edit.
 
 ## [Unreleased]
 
+### Changed
+- `maket_gmail` is now draft-only: Maket never calls any send endpoint.
+  `action=draft` returns a `#drafts/<message-id>` deep link that the user
+  clicks to review and send from Gmail themselves.
+- Gmail consent splits into two tiers at connect time. Default asks only
+  for `gmail.compose` ("Manage drafts and send emails") — the "Read your
+  Gmail" prompt is gone. Pass `action=connect with_read=true` to additionally
+  request `gmail.readonly` for `search` / `read`. When those actions are
+  called without the read grant, the tool returns an MCP `next:` hint that
+  walks the agent through the re-authorise flow.
+- Doc metadata gains `emailDraftUrl` + `emailDraftRole: "body"|"attachment"`.
+  On draft creation the URL is written to the body doc and mirrored onto
+  every attached doc, so each artefact carries a one-click review pointer
+  back into Gmail.
+
+### Added
+- A discreet **Draft ready / In draft** indicator in the sidebar (both list
+  and grid views) and in the Board doc label — leading cyan dot, trailing
+  external-link glyph, opens the Gmail draft in a new tab.
+
 ### Internal
 - CI now runs the full test suite with coverage (v8 provider) on every push
   and pull-request. A shields.io-compatible badge is regenerated on every

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,6 +61,12 @@ Always use `text(t, { isError?, next? })` from `packages/server/src/tools/_helpe
 - Co-located: `foo.ts` + `foo.test.ts`. DB tests use `createSQLiteStore(":memory:")` — never touch the filesystem.
 - Coverage thresholds in `vitest.config.ts` (core 90 %, services 80 %).
 
+### Gmail is draft-only, read is opt-in
+- Maket never calls `users.messages.send` nor `users.drafts.send`. The user reviews in Gmail and sends themselves. No exception.
+- `gmail.compose` is always requested. `gmail.readonly` is requested only when the caller passes `with_read=true` at `connect`. Guard `search` / `read` behind `gmailClient.grants().read`; on miss, return `text(…, { next: ["maket_gmail action=connect with_read=true"] })`.
+- The OAuth app is unverified and stays that way — we don't pay CASA for an open-source tool. Users see Google's "Advanced → proceed" screen once; that's the deal.
+- On successful draft creation, write `doc.meta.emailDraftUrl` + `emailDraftRole: "body"|"attachment"` on the body doc AND mirror both onto every attached doc, so each artefact carries a one-click review pointer back into Gmail.
+
 ## Git flow & changelog
 
 - Feature branches only; `main` takes release commits directly (`chore(release): vX.Y.Z`).

--- a/README.md
+++ b/README.md
@@ -160,29 +160,20 @@ Override with environment variables:
 | `MAKET_DB` | `$MAKET_DATA_DIR/documents.db` | SQLite path |
 | `GOOGLE_CLIENT_ID` / `GOOGLE_CLIENT_SECRET` | — | Gmail OAuth credentials (optional) |
 
-### Gmail integration (optional)
+### Gmail integration (optional, power-user)
 
-#### What Maket does (and doesn't) do with your Gmail
+Maket can turn a composed document into a Gmail draft (with PDF attachments). It **only creates drafts** — never sends. You review the draft in Gmail and click Send yourself.
 
-Maket only ever **creates drafts**. It never calls any send endpoint. You review the draft in Gmail, you click Send. The code is open — grep `users.drafts.send` or `users.messages.send` in `packages/server/src/tools/gmail.ts`, you won't find a call site.
+Setup takes about 10 minutes: you register your own OAuth Desktop client in Google Cloud Console, enable the Gmail API, add yourself as a test user, and paste the JSON into Maket's setup form. Credentials live under `~/.maket/` with owner-only permissions — nothing in the repo, nothing on any server.
 
-Two authorisation levels, you pick at connect time:
+**Full walkthrough + troubleshooting: [docs/gmail-setup.md](docs/gmail-setup.md).**
 
-- **Draft only** (default) — Google asks: *"Manage drafts and send emails"*. Maket uses the draft half; the send half is the floor Google offers, not what Maket does.
-- **Draft + read** (opt-in with `with_read=true`) — also grants *"Read your Gmail"*. Enables `search` / `read` actions so the AI can reference past threads when composing.
+Quick CLI helpers once set up:
 
-#### The "unverified app" screen — yes, you'll see it
-
-Maket is open source and free. Getting Google to drop the "unverified app" warning requires an annual security audit (CASA) that costs **$500–$4500/yr**. I'm not paying that for a free tool. You'll see the red screen once, click **Advanced → Go to maket (unsafe)**, and proceed. Normal for a small open-source app you run on your own machine.
-
-If you don't trust that — good instinct. Read `packages/server/src/services/gmail-client.ts` and `packages/server/src/tools/gmail.ts`, or ask your AI assistant to audit them. Nothing leaves your machine except the draft you just composed, going to your own Gmail.
-
-#### Setup
-
-1. Create OAuth credentials at [Google Cloud Console](https://console.cloud.google.com/apis/credentials).
-2. Add redirect URI: `http://localhost:3333/auth/google/callback`.
-3. Copy `.env.example` → `.env` and set `GOOGLE_CLIENT_ID` / `GOOGLE_CLIENT_SECRET`.
-4. Run `maket_gmail connect` in your AI assistant (add `with_read=true` if you also want inbox reading). Follow the browser flow.
+```bash
+maket gmail status         # check whether credentials are in place
+maket gmail reset --force  # wipe and start over
+```
 
 ### Bootstrap a downstream workspace
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Maket
 
-**Turn your AI assistant into a visual designer.** Describe what you want — a poster, a flyer, a product label, a social post — and the AI assistant composes it as an HTML/CSS document with precise typography, brand chartes, and your image library. A live preview updates in real time. Export to PDF or send via Gmail when you're done.
+**Turn your AI assistant into a visual designer.** Describe what you want — a poster, a flyer, a product label, a social post — and the AI assistant composes it as an HTML/CSS document with precise typography, brand chartes, and your image library. A live preview updates in real time. Export to PDF or hand it off to Gmail as a draft when you're done.
 
 [![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
 [![Node](https://img.shields.io/badge/node-%3E%3D22-brightgreen.svg)](https://nodejs.org/)
@@ -30,7 +30,7 @@ Your AI assistant is good at writing. But design is about space, hierarchy, and 
 - **Brand chartes** — Define design tokens (colors, fonts, spacing, shadows) once; Maket enforces them during composition.
 - **Image library** — Drop images in, tag them, the AI picks the right one for the brief.
 - **PDF export** — Print-ready output via headless Chromium.
-- **Gmail send** — Compose an email document and send it as a PDF attachment.
+- **Gmail drafts** — Compose an email document and hand it off to Gmail as a draft; you review and send yourself.
 - **Paper & screen formats** — A2–A8, plus DESKTOP/TABLET/MOBILE aspect ratios for digital mockups.
 - **Agent skills included** — Three skills (`maket`, `maket-charte`, `maket-review`) that teach the AI assistant how to design, brand, and review documents.
 
@@ -162,10 +162,27 @@ Override with environment variables:
 
 ### Gmail integration (optional)
 
+#### What Maket does (and doesn't) do with your Gmail
+
+Maket only ever **creates drafts**. It never calls any send endpoint. You review the draft in Gmail, you click Send. The code is open — grep `users.drafts.send` or `users.messages.send` in `packages/server/src/tools/gmail.ts`, you won't find a call site.
+
+Two authorisation levels, you pick at connect time:
+
+- **Draft only** (default) — Google asks: *"Manage drafts and send emails"*. Maket uses the draft half; the send half is the floor Google offers, not what Maket does.
+- **Draft + read** (opt-in with `with_read=true`) — also grants *"Read your Gmail"*. Enables `search` / `read` actions so the AI can reference past threads when composing.
+
+#### The "unverified app" screen — yes, you'll see it
+
+Maket is open source and free. Getting Google to drop the "unverified app" warning requires an annual security audit (CASA) that costs **$500–$4500/yr**. I'm not paying that for a free tool. You'll see the red screen once, click **Advanced → Go to maket (unsafe)**, and proceed. Normal for a small open-source app you run on your own machine.
+
+If you don't trust that — good instinct. Read `packages/server/src/services/gmail-client.ts` and `packages/server/src/tools/gmail.ts`, or ask your AI assistant to audit them. Nothing leaves your machine except the draft you just composed, going to your own Gmail.
+
+#### Setup
+
 1. Create OAuth credentials at [Google Cloud Console](https://console.cloud.google.com/apis/credentials).
 2. Add redirect URI: `http://localhost:3333/auth/google/callback`.
 3. Copy `.env.example` → `.env` and set `GOOGLE_CLIENT_ID` / `GOOGLE_CLIENT_SECRET`.
-4. Run `maket_gmail connect` in your AI assistant — follow the browser flow to grant access.
+4. Run `maket_gmail connect` in your AI assistant (add `with_read=true` if you also want inbox reading). Follow the browser flow.
 
 ### Bootstrap a downstream workspace
 

--- a/docs/gmail-setup.md
+++ b/docs/gmail-setup.md
@@ -1,0 +1,145 @@
+# Gmail integration — setup guide
+
+Maket can turn a document into a Gmail draft with PDF attachments. The feature is **opt-in**: setup takes about 10 minutes and requires you to register Maket as your own OAuth application with Google.
+
+Why the setup friction? Maket is free and open source. Removing the "unverified app" warning from Google's consent screen would require an annual CASA audit that costs $500–$4500 per year — not a cost the project is willing to carry. Each user registers their own OAuth client instead, which stays on their machine and is never shared.
+
+## What Maket does (and doesn't) do
+
+- **Creates drafts** in your Gmail. That's the whole surface. Maket never calls `users.messages.send` or `users.drafts.send`. You review every draft and click Send yourself, from Gmail's UI.
+- **Optionally reads your inbox** if you pass `with_read=true` at connect time. The default is drafts only — Google's consent screen asks for *"Manage drafts and send emails"* and nothing else.
+- **Stores credentials locally** under `$MAKET_DATA_DIR/` with owner-only (0600) file permissions. Nothing leaves your machine.
+
+You are the OAuth application owner. That means:
+
+- You create the project in **your own** Google Cloud account.
+- You enable the Gmail API on that project.
+- You add your email as a test user so the flow can complete.
+- You own the client_id / client_secret that Maket uses to talk to Google.
+
+## Setup — step by step
+
+### 1. Create a Google Cloud project
+
+1. Open the [Google Cloud Console](https://console.cloud.google.com).
+2. In the top bar, click the project selector → **New project**.
+3. Name it `Maket` (or whatever). Create.
+
+### 2. Enable the Gmail API
+
+1. Go to the project's [Gmail API page](https://console.cloud.google.com/apis/library/gmail.googleapis.com).
+2. Click **Enable**.
+3. Propagation is usually instant but Google warns it can take a few minutes.
+
+### 3. Configure the OAuth consent screen
+
+Recent Google Cloud Console versions split this into four quick wizard steps:
+
+1. [Open the OAuth consent screen](https://console.cloud.google.com/auth/overview).
+2. Step 1 — **App Information**: app name `Maket`, user support email = your email.
+3. Step 2 — **Audience**: select **External** (required unless the Google account is part of a Workspace organization you want to scope to).
+4. Step 3 — **Contact Information**: developer contact email = your email.
+5. Step 4 — **Finish**: accept the terms and create.
+
+### 4. Add yourself as a test user
+
+Until the app is published and verified by Google, only explicitly-listed test users can authenticate. Your own email is not on that list by default.
+
+1. Open [Audience](https://console.cloud.google.com/auth/audience).
+2. Publishing status should read **Testing** — leave it there. Moving to Production without a CASA audit will get the Gmail scopes silently blocked.
+3. In the **Test users** section, click **Add users** and paste your email address (and any other email you want to test with — up to 100 total).
+4. Save.
+
+### 5. Create the OAuth client
+
+1. Open [Credentials](https://console.cloud.google.com/apis/credentials).
+2. Click **Create credentials → OAuth client ID**.
+3. Application type: **Desktop app**. (Don't pick Web app — Desktop accepts any `http://localhost:*` redirect without explicit URL registration, which makes port changes painless later.)
+4. Name: `Maket desktop`.
+5. Click **Create**.
+6. The popup shows your `client_id` and `client_secret`. Click **Download JSON** — you'll paste this into Maket in a moment. Keep the file local.
+
+### 6. Hand the credentials to Maket
+
+Start Maket locally (`npx -y @ng-galien/maket start`, or `npm run dev` in a clone).
+
+The easy path — form:
+
+1. Open `http://localhost:24842/setup/gmail` in your browser (replace the port if you changed `MAKET_PORT`).
+2. Paste the full JSON from the file Google gave you.
+3. Tick *"also request inbox reading"* if you want the AI to search and read your mail. Leave it unchecked for the default draft-only mode.
+4. Click **Save credentials**.
+
+Alternatives:
+
+- **Drop the file**: rename the downloaded JSON to `google-credentials.json` and place it at `$MAKET_DATA_DIR/google-credentials.json` (defaults to `~/.maket/google-credentials.json`). Make sure permissions are 0600.
+- **Env vars**: set `GOOGLE_CLIENT_ID` and `GOOGLE_CLIENT_SECRET` in your `.env`. Lower friction for dev workflows.
+
+### 7. Run the OAuth flow
+
+From your AI assistant (Claude Desktop, Claude Code, Codex, etc.):
+
+```
+maket_gmail action=connect
+```
+
+Add `with_read=true` to also request inbox read access.
+
+The browser opens Google's consent screen. You'll see:
+
+1. A red **"Google hasn't verified this app"** warning. This is expected for any unverified OAuth app — your own project in Testing mode is unverified by design.
+2. Click **Advanced → Go to Maket (unsafe)**.
+3. Grant the requested scopes (`gmail.compose`, and optionally `gmail.readonly`).
+4. The browser confirms "Gmail connected" and you can close the tab.
+
+From this point, `maket_gmail action=draft doc=<name> page=<n>` turns any document into a Gmail draft.
+
+## Where credentials live
+
+Maket persists two files in `$MAKET_DATA_DIR/` (default `~/.maket/`):
+
+| File | Contents | Permissions |
+|------|----------|-------------|
+| `google-credentials.json` | Your OAuth Desktop client (client_id + client_secret) | 0600 |
+| `google-token.json` | Refresh token + `with_read` flag | 0600 |
+
+Both files are owner-only. Maket never uploads them anywhere. Deleting either file logs you out — the next `maket_gmail connect` will re-run the OAuth flow.
+
+## CLI helpers
+
+```bash
+maket gmail status   # show whether credentials and refresh token exist
+maket gmail reset    # delete both files (asks for confirmation)
+maket gmail reset --force   # delete without prompting
+```
+
+## Limits of Testing mode
+
+Testing mode is the right choice for a free open-source tool, but it comes with constraints:
+
+- **100 test users max.** You must add every email that should be able to connect.
+- **Refresh tokens expire after 7 days.** Users re-run `maket_gmail connect` weekly. Google enforces this unconditionally in Testing mode.
+- **The "unverified app" warning stays visible.** There is no way to remove it without verification.
+- **Do not click "Publish app"** in the OAuth consent screen. For Gmail scopes, publishing without a CASA security assessment causes Google to block new sign-ins. The scopes are classified as *restricted*, which triggers mandatory verification for non-Testing apps.
+
+If Maket someday needs to serve thousands of users without CASA, the realistic alternatives are (a) a hosted auth proxy or (b) a third-party provider like Nylas. Both change the architecture meaningfully — today's design targets individuals and small teams running their own instance.
+
+## Troubleshooting
+
+**`Error 403: access_denied` on the Google consent screen**
+Your email is not in the Test users list for the OAuth project. Add it at [Audience → Test users](https://console.cloud.google.com/auth/audience).
+
+**`Gmail API has not been used in project N before or it is disabled`**
+You skipped step 2. Open the URL Google gave you (or the [Gmail API library page](https://console.cloud.google.com/apis/library/gmail.googleapis.com)) and click Enable. Allow a minute or two for propagation.
+
+**`Gmail credentials not configured`**
+Maket couldn't find `google-credentials.json`. Use the setup form at `http://localhost:24842/setup/gmail`, drop the JSON manually at `~/.maket/google-credentials.json`, or set `GOOGLE_CLIENT_ID` / `GOOGLE_CLIENT_SECRET` in `.env`.
+
+**Refresh token expired (`invalid_grant`)**
+Expected in Testing mode after 7 days. Run `maket_gmail action=connect` again.
+
+**Start over from scratch**
+`maket gmail reset` removes both credential files. Re-run the setup form to reconnect.
+
+**Unsure what state you're in**
+`maket gmail status` prints which files exist and their permissions.

--- a/packages/client/src/components/DocsTab.tsx
+++ b/packages/client/src/components/DocsTab.tsx
@@ -27,6 +27,7 @@ import {
 	sendRenameDoc,
 	wsSend,
 } from "../store/ws";
+import { DraftPill } from "./shared/DraftPill";
 import { HoldToDelete } from "./shared/HoldToDelete";
 
 const DRAG_MIME = "application/x-maket-doc";
@@ -1049,6 +1050,14 @@ function DocCard({
 							{(doc.rating ?? 0) > 0 && (
 								<span className="text-amber-500">★{doc.rating}</span>
 							)}
+							{doc.emailDraftUrl && (
+								<span className="ml-auto">
+									<DraftPill
+										kind={doc.emailDraftRole ?? "body"}
+										url={doc.emailDraftUrl}
+									/>
+								</span>
+							)}
 						</div>
 					</div>
 					<button
@@ -1205,9 +1214,17 @@ function DocRow({
 									<span className="tabular-nums">{doc.rating}</span>
 								</span>
 							)}
+							{doc.emailDraftUrl && (
+								<span className="ml-auto">
+									<DraftPill
+										kind={doc.emailDraftRole ?? "body"}
+										url={doc.emailDraftUrl}
+									/>
+								</span>
+							)}
 							{doc.updatedAt && (
 								<span
-									className="ml-auto text-text-3/80 tabular-nums"
+									className={`${doc.emailDraftUrl ? "" : "ml-auto"} text-text-3/80 tabular-nums`}
 									title={doc.updatedAt}
 								>
 									{relativeTime(doc.updatedAt, navigator.language)}

--- a/packages/client/src/components/WorkspaceDoc.tsx
+++ b/packages/client/src/components/WorkspaceDoc.tsx
@@ -87,7 +87,9 @@ export const WorkspaceDoc = memo(function WorkspaceDoc({
 					{doc.meta?.emailDraftUrl && (
 						<DraftPill
 							kind={
-								(doc.meta?.emailDraftRole as "body" | "attachment") ?? "body"
+								doc.meta?.emailDraftRole === "attachment"
+									? "attachment"
+									: "body"
 							}
 							url={doc.meta.emailDraftUrl}
 						/>

--- a/packages/client/src/components/WorkspaceDoc.tsx
+++ b/packages/client/src/components/WorkspaceDoc.tsx
@@ -2,6 +2,7 @@ import { X } from "lucide-react";
 import { memo } from "react";
 import { useDocByName, useStore } from "../store/useStore";
 import { PageCanvas } from "./PageCanvas";
+import { DraftPill } from "./shared/DraftPill";
 
 const PAGE_GAP = 12;
 
@@ -83,6 +84,14 @@ export const WorkspaceDoc = memo(function WorkspaceDoc({
 					<span className="text-2xs text-text-3 shrink-0">
 						{doc.canvas.format} · {doc.pages.length}p
 					</span>
+					{doc.meta?.emailDraftUrl && (
+						<DraftPill
+							kind={
+								(doc.meta?.emailDraftRole as "body" | "attachment") ?? "body"
+							}
+							url={doc.meta.emailDraftUrl}
+						/>
+					)}
 					{pendingCount > 0 && (
 						<span className="text-2xs font-bold text-white bg-accent rounded-full px-1.5 py-px min-w-[18px] text-center shrink-0">
 							{pendingCount}

--- a/packages/client/src/components/shared/DraftPill.test.tsx
+++ b/packages/client/src/components/shared/DraftPill.test.tsx
@@ -1,0 +1,37 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import { DraftPill } from "./DraftPill";
+
+afterEach(() => cleanup());
+
+describe("DraftPill", () => {
+	const url = "https://mail.google.com/mail/u/0/#drafts/MSG_42";
+
+	it("renders the body label with the url on the anchor", () => {
+		render(<DraftPill kind="body" url={url} />);
+		const anchor = screen.getByRole("link");
+		expect(anchor).toHaveAttribute("href", url);
+		expect(anchor).toHaveAttribute("target", "_blank");
+		expect(anchor).toHaveAttribute("rel", "noopener noreferrer");
+		expect(anchor.textContent).toMatch(/Draft ready|Brouillon prêt/);
+	});
+
+	it("swaps the label for kind=attachment", () => {
+		render(<DraftPill kind="attachment" url={url} />);
+		const anchor = screen.getByRole("link");
+		expect(anchor.textContent).toMatch(/In draft|Dans un brouillon/);
+	});
+
+	it("stops click propagation so the parent row doesn't steal focus", () => {
+		let parentClicks = 0;
+		render(
+			<button type="button" onClick={() => parentClicks++}>
+				<DraftPill kind="body" url={url} />
+			</button>,
+		);
+		const anchor = screen.getByRole("link");
+		anchor.addEventListener("click", (e) => e.preventDefault());
+		anchor.click();
+		expect(parentClicks).toBe(0);
+	});
+});

--- a/packages/client/src/components/shared/DraftPill.tsx
+++ b/packages/client/src/components/shared/DraftPill.tsx
@@ -1,0 +1,39 @@
+import { ExternalLink } from "lucide-react";
+import { useT } from "../../i18n/useT";
+
+export interface DraftPillProps {
+	kind: "body" | "attachment";
+	url: string;
+}
+
+export function DraftPill({ kind, url }: DraftPillProps) {
+	const t = useT();
+	const labelKey = kind === "body" ? "doc_draft_body" : "doc_draft_attachment";
+	const ariaKey =
+		kind === "body" ? "doc_draft_body_aria" : "doc_draft_attachment_aria";
+
+	return (
+		<a
+			href={url}
+			target="_blank"
+			rel="noopener noreferrer"
+			aria-label={t(ariaKey)}
+			title={t(ariaKey)}
+			onClick={(e) => e.stopPropagation()}
+			className="group inline-flex items-center gap-1.5 text-2xs font-medium text-text-2 hover:text-accent transition-colors shrink-0"
+		>
+			<span
+				aria-hidden="true"
+				className="inline-block w-1.5 h-1.5 rounded-full bg-accent shrink-0"
+			/>
+			<span className="whitespace-nowrap group-hover:underline underline-offset-2 decoration-accent/60">
+				{t(labelKey)}
+			</span>
+			<ExternalLink
+				size={10}
+				aria-hidden="true"
+				className="text-text-3 group-hover:text-accent shrink-0"
+			/>
+		</a>
+	);
+}

--- a/packages/client/src/i18n/en.json
+++ b/packages/client/src/i18n/en.json
@@ -132,5 +132,10 @@
 
 	"watermark_title": "Maket",
 	"watermark_pan": "Space + drag to pan",
-	"watermark_zoom": "Scroll to zoom"
+	"watermark_zoom": "Scroll to zoom",
+
+	"doc_draft_body": "Draft ready",
+	"doc_draft_body_aria": "Open this email's draft in Gmail",
+	"doc_draft_attachment": "In draft",
+	"doc_draft_attachment_aria": "Open the Gmail draft this doc is attached to"
 }

--- a/packages/client/src/i18n/fr.json
+++ b/packages/client/src/i18n/fr.json
@@ -132,5 +132,10 @@
 
 	"watermark_title": "Maket",
 	"watermark_pan": "Space + glisser pour se déplacer",
-	"watermark_zoom": "Molette pour zoomer"
+	"watermark_zoom": "Molette pour zoomer",
+
+	"doc_draft_body": "Brouillon prêt",
+	"doc_draft_body_aria": "Ouvrir ce brouillon dans Gmail",
+	"doc_draft_attachment": "Dans un brouillon",
+	"doc_draft_attachment_aria": "Ouvrir le brouillon Gmail auquel ce doc est attaché"
 }

--- a/packages/client/src/store/types.ts
+++ b/packages/client/src/store/types.ts
@@ -53,4 +53,8 @@ export interface DocSummary {
 	/** Primary colour of the associated charte — renders as a tiny dot in
 	 * the doc row so you can scan the catalog by brand at a glance. */
 	charteColor?: string;
+	/** Gmail deep link to the draft this doc is part of. Surfaced as a
+	 * discreet "Draft ready / In draft" pill in the sidebar when present. */
+	emailDraftUrl?: string;
+	emailDraftRole?: "body" | "attachment";
 }

--- a/packages/server/src/bootstrap.ts
+++ b/packages/server/src/bootstrap.ts
@@ -12,6 +12,7 @@ import { createAppRouter } from "./routes/app.routes.js";
 import { createAssetsRouter } from "./routes/assets.routes.js";
 import { createChartesRouter } from "./routes/chartes.routes.js";
 import { createExportRouter } from "./routes/export.routes.js";
+import { createGmailRouter } from "./routes/gmail.routes.js";
 import { createMcpRouter } from "./routes/mcp.routes.js";
 import { createOAuthRouter } from "./routes/oauth.routes.js";
 import { createThumbnailRouter } from "./routes/thumbnail.routes.js";
@@ -114,6 +115,7 @@ export function createAppContainer(
 		exportRouter: asFunction(createExportRouter).singleton(),
 		thumbnailRouter: asFunction(createThumbnailRouter).singleton(),
 		oauthRouter: asFunction(createOAuthRouter).singleton(),
+		gmailRouter: asFunction(createGmailRouter).singleton(),
 		mcpRouter: asFunction(createMcpRouter).singleton(),
 	});
 

--- a/packages/server/src/lib/local-origin.ts
+++ b/packages/server/src/lib/local-origin.ts
@@ -11,6 +11,8 @@
  *  - Requests where Origin and Host both resolve to a loopback name
  */
 
+import type { NextFunction, Request, Response } from "express";
+
 const LOCAL_HOSTS = new Set(["localhost", "127.0.0.1", "::1", "0.0.0.0"]);
 
 /** True if the given Host: or origin host (with optional port) is loopback. */
@@ -50,4 +52,25 @@ export function isLoopbackReferer(referer: string | undefined | null): boolean {
 	} catch {
 		return false;
 	}
+}
+
+/**
+ * Reject browser-initiated requests whose Referer points outside loopback.
+ * The global Origin/Host middleware already blocks XHR/fetch from any other
+ * origin, but a top-level navigation (`window.open`, `location.href`) carries
+ * no Origin header — only Referer. This guard catches that vector.
+ *
+ * Native HTTP clients (curl, the MCP bridge) send neither header and pass.
+ */
+export function requireBrowserContextLoopback(
+	req: Request,
+	res: Response,
+	next: NextFunction,
+): void {
+	const referer = req.headers.referer;
+	if (referer && !isLoopbackReferer(referer)) {
+		res.status(403).end();
+		return;
+	}
+	next();
 }

--- a/packages/server/src/routes/export.routes.ts
+++ b/packages/server/src/routes/export.routes.ts
@@ -4,15 +4,9 @@
  * (gzipped JSON bundle with documents + referenced chartes).
  */
 
-import {
-	Router as createRouter,
-	type NextFunction,
-	type Request,
-	type Response,
-	type Router,
-} from "express";
+import { Router as createRouter, type Router } from "express";
 import { BodyTooLargeError, readBoundedBody } from "../lib/bounded-body.js";
-import { isLoopbackReferer } from "../lib/local-origin.js";
+import { requireBrowserContextLoopback } from "../lib/local-origin.js";
 import {
 	bundleFilename,
 	decodeBundle,
@@ -46,27 +40,6 @@ export interface ExportRouterDeps {
 
 function safeName(raw: string): string {
 	return raw.replace(/[^a-zA-Z0-9_-]/g, "_").slice(0, 80) || "export";
-}
-
-/**
- * Reject browser-initiated requests whose Referer points outside loopback.
- * The global Origin/Host middleware already blocks XHR/fetch from any other
- * origin, but a top-level navigation (`window.open`, `location.href`) carries
- * no Origin header — only Referer. This guard catches that vector.
- *
- * Native HTTP clients (curl, the MCP bridge) send neither header and pass.
- */
-function requireBrowserContextLoopback(
-	req: Request,
-	res: Response,
-	next: NextFunction,
-): void {
-	const referer = req.headers.referer;
-	if (referer && !isLoopbackReferer(referer)) {
-		res.status(403).end();
-		return;
-	}
-	next();
 }
 
 export function createExportRouter({

--- a/packages/server/src/routes/gmail.routes.test.ts
+++ b/packages/server/src/routes/gmail.routes.test.ts
@@ -1,0 +1,140 @@
+import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import express from "express";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { startTestApp } from "../../tests/helpers.js";
+import type { Config } from "../services/config.js";
+import type { GmailClient } from "../services/gmail-client.js";
+import { createGmailRouter } from "./gmail.routes.js";
+
+describe("gmail routes — onboarding + auth-url", () => {
+	let dataDir: string;
+	let baseUrl: string;
+	let close: () => Promise<void>;
+	let gmailClient: GmailClient;
+
+	beforeEach(async () => {
+		dataDir = mkdtempSync(join(tmpdir(), "maket-gmail-route-"));
+		gmailClient = {
+			getAuthUrl: vi.fn(
+				async (_redirect, opts) =>
+					`https://accounts.google.com/o/oauth2/auth?with_read=${opts?.withRead ? "1" : "0"}`,
+			),
+		} as unknown as GmailClient;
+		const config = { DATA_DIR: dataDir, PORT: 24842 } as Config;
+		const app = express();
+		app.use(createGmailRouter({ config, gmailClient }));
+		({ baseUrl, close } = await startTestApp(app));
+	});
+
+	afterEach(async () => {
+		await close();
+		rmSync(dataDir, { recursive: true, force: true });
+	});
+
+	it("GET /setup/gmail returns the paste form", async () => {
+		const res = await fetch(`${baseUrl}/setup/gmail`);
+		expect(res.status).toBe(200);
+		expect(res.headers.get("content-type")).toContain("text/html");
+		const html = await res.text();
+		expect(html).toMatch(/Connect Gmail/);
+		expect(html).toMatch(/name="credentials"/);
+		expect(html).toMatch(/action="\/api\/gmail\/credentials"/);
+	});
+
+	it("POST /api/gmail/credentials saves the Desktop JSON and serves a success page", async () => {
+		const body = new URLSearchParams({
+			credentials: JSON.stringify({
+				installed: {
+					client_id: "id-xyz",
+					client_secret: "secret-xyz",
+					redirect_uris: ["http://localhost"],
+				},
+			}),
+		});
+		const res = await fetch(`${baseUrl}/api/gmail/credentials`, {
+			method: "POST",
+			headers: { "Content-Type": "application/x-www-form-urlencoded" },
+			body,
+		});
+		expect(res.status).toBe(200);
+		const html = await res.text();
+		expect(html).toMatch(/Saved/);
+		expect(html).toMatch(/\/api\/gmail\/auth-url/);
+		const saved = join(dataDir, "google-credentials.json");
+		expect(existsSync(saved)).toBe(true);
+		const parsed = JSON.parse(readFileSync(saved, "utf-8"));
+		expect(parsed.installed.client_id).toBe("id-xyz");
+		expect(parsed.installed.client_secret).toBe("secret-xyz");
+	});
+
+	it("POST accepts the `web` key shape (not just `installed`)", async () => {
+		const body = new URLSearchParams({
+			credentials: JSON.stringify({
+				web: { client_id: "web-id", client_secret: "web-secret" },
+			}),
+		});
+		const res = await fetch(`${baseUrl}/api/gmail/credentials`, {
+			method: "POST",
+			headers: { "Content-Type": "application/x-www-form-urlencoded" },
+			body,
+		});
+		expect(res.status).toBe(200);
+		const saved = JSON.parse(
+			readFileSync(join(dataDir, "google-credentials.json"), "utf-8"),
+		);
+		expect(saved.installed.client_id).toBe("web-id");
+	});
+
+	it("POST renders the form with an error when JSON is malformed", async () => {
+		const body = new URLSearchParams({ credentials: "{ not json" });
+		const res = await fetch(`${baseUrl}/api/gmail/credentials`, {
+			method: "POST",
+			headers: { "Content-Type": "application/x-www-form-urlencoded" },
+			body,
+		});
+		expect(res.status).toBe(400);
+		const html = await res.text();
+		// The apostrophe in "didn't" is HTML-escaped to &#39; when rendered.
+		expect(html).toMatch(/didn(?:'|&#39;)t parse as JSON/);
+	});
+
+	it("POST renders the form with an error when client_id or secret is missing", async () => {
+		const body = new URLSearchParams({
+			credentials: JSON.stringify({ installed: { client_id: "only-id" } }),
+		});
+		const res = await fetch(`${baseUrl}/api/gmail/credentials`, {
+			method: "POST",
+			headers: { "Content-Type": "application/x-www-form-urlencoded" },
+			body,
+		});
+		expect(res.status).toBe(400);
+		const html = await res.text();
+		expect(html).toMatch(/Missing `client_id` or `client_secret`/);
+	});
+
+	it("GET /api/gmail/auth-url redirects to Google with the drafts-only scope by default", async () => {
+		const res = await fetch(`${baseUrl}/api/gmail/auth-url`, {
+			redirect: "manual",
+		});
+		expect(res.status).toBe(302);
+		expect(res.headers.get("location")).toMatch(/with_read=0$/);
+		expect(gmailClient.getAuthUrl).toHaveBeenCalledWith(
+			"http://localhost:24842/auth/google/callback",
+			{ withRead: false },
+		);
+	});
+
+	it("GET /api/gmail/auth-url?with_read=1 propagates the withRead option", async () => {
+		const res = await fetch(`${baseUrl}/api/gmail/auth-url?with_read=1`, {
+			redirect: "manual",
+		});
+		expect(res.status).toBe(302);
+		expect(res.headers.get("location")).toMatch(/with_read=1$/);
+		expect(gmailClient.getAuthUrl).toHaveBeenCalledWith(
+			"http://localhost:24842/auth/google/callback",
+			{ withRead: true },
+		);
+	});
+});

--- a/packages/server/src/routes/gmail.routes.test.ts
+++ b/packages/server/src/routes/gmail.routes.test.ts
@@ -126,6 +126,24 @@ describe("gmail routes — onboarding + auth-url", () => {
 		);
 	});
 
+	it("rejects POST /api/gmail/credentials when Referer is non-loopback", async () => {
+		const body = new URLSearchParams({
+			credentials: JSON.stringify({
+				installed: { client_id: "id", client_secret: "secret" },
+			}),
+		});
+		const res = await fetch(`${baseUrl}/api/gmail/credentials`, {
+			method: "POST",
+			headers: {
+				"Content-Type": "application/x-www-form-urlencoded",
+				Referer: "https://evil.example/",
+			},
+			body,
+		});
+		expect(res.status).toBe(403);
+		expect(existsSync(join(dataDir, "google-credentials.json"))).toBe(false);
+	});
+
 	it("GET /api/gmail/auth-url?with_read=1 propagates the withRead option", async () => {
 		const res = await fetch(`${baseUrl}/api/gmail/auth-url?with_read=1`, {
 			redirect: "manual",

--- a/packages/server/src/routes/gmail.routes.ts
+++ b/packages/server/src/routes/gmail.routes.ts
@@ -11,6 +11,7 @@
 import { mkdirSync, renameSync, writeFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import express, { Router as createRouter, type Router } from "express";
+import { requireBrowserContextLoopback } from "../lib/local-origin.js";
 import type { Config } from "../services/config.js";
 import type { GmailClient } from "../services/gmail-client.js";
 
@@ -140,6 +141,11 @@ export function createGmailRouter({
 	gmailClient,
 }: GmailRouterDeps): Router {
 	const router = createRouter();
+
+	// The credentials endpoint writes a secret file to disk — gate the whole
+	// router behind the same Referer check the export routes use so a hostile
+	// site can't drive a top-level navigation to overwrite `google-credentials.json`.
+	router.use(requireBrowserContextLoopback);
 
 	// The form uses url-encoded POST so it works without JS.
 	router.use(express.urlencoded({ extended: false, limit: "64kb" }));

--- a/packages/server/src/routes/gmail.routes.ts
+++ b/packages/server/src/routes/gmail.routes.ts
@@ -1,0 +1,221 @@
+/**
+ * gmail routes — Gmail credentials onboarding (paste the OAuth Desktop JSON
+ * once, hit Connect, done) and a direct auth-URL redirect that bypasses the
+ * MCP tool round-trip for users who walk the UI path.
+ *
+ * The paste form saves `google-credentials.json` into `config.DATA_DIR` in
+ * the exact shape gmail-client.ts's `loadCredentials` expects (the
+ * `{ installed: {...} }` object Google hands you from Cloud Console).
+ */
+
+import { mkdirSync, renameSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import express, { Router as createRouter, type Router } from "express";
+import type { Config } from "../services/config.js";
+import type { GmailClient } from "../services/gmail-client.js";
+
+export interface GmailRouterDeps {
+	config: Config;
+	gmailClient: GmailClient;
+}
+
+/** Minimal HTML-escape for dynamic bits in the pages below. */
+function escapeHtml(s: string): string {
+	return s
+		.replace(/&/g, "&amp;")
+		.replace(/</g, "&lt;")
+		.replace(/>/g, "&gt;")
+		.replace(/"/g, "&quot;")
+		.replace(/'/g, "&#39;");
+}
+
+function shell(title: string, body: string): string {
+	return `<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>${escapeHtml(title)}</title>
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<style>
+	body { font-family: system-ui, -apple-system, sans-serif; background: #f5f5f5; margin: 0; padding: 2rem 1rem; color: #1B263B; }
+	main { max-width: 620px; margin: 0 auto; background: #fff; padding: 2.5rem; border-radius: 12px; box-shadow: 0 4px 20px rgba(0,0,0,0.06); }
+	h1 { font-size: 1.5rem; margin: 0 0 0.5rem; color: #0D1B2A; font-weight: 600; letter-spacing: -0.01em; }
+	h1 .dot { color: #00A8B5; }
+	p.lead { color: #415A77; margin: 0 0 1.5rem; line-height: 1.5; font-size: 0.95rem; }
+	ol { color: #415A77; font-size: 0.9rem; line-height: 1.7; padding-left: 1.25rem; margin: 0 0 1.5rem; }
+	ol a { color: #00A8B5; }
+	label { display: block; font-size: 0.85rem; font-weight: 600; color: #1B263B; margin: 1rem 0 0.35rem; }
+	textarea { width: 100%; box-sizing: border-box; min-height: 180px; font-family: "SF Mono", Menlo, monospace; font-size: 0.78rem; padding: 0.75rem; border: 1px solid #cbd5e1; border-radius: 6px; resize: vertical; background: #fafafa; color: #0D1B2A; }
+	textarea:focus { outline: 2px solid #00A8B5; outline-offset: -1px; border-color: #00A8B5; }
+	.opts { margin: 1rem 0; display: flex; align-items: center; gap: 0.5rem; font-size: 0.85rem; color: #415A77; }
+	button { background: #0D1B2A; color: #fff; border: 0; padding: 0.7rem 1.25rem; border-radius: 6px; font-weight: 600; font-size: 0.9rem; cursor: pointer; margin-top: 0.5rem; transition: background 0.15s; }
+	button:hover { background: #1B263B; }
+	button.secondary { background: #00A8B5; }
+	button.secondary:hover { background: #0891b2; }
+	.msg { margin: 1rem 0; padding: 0.75rem 1rem; border-radius: 6px; font-size: 0.85rem; }
+	.msg.err { background: #fef2f2; color: #991b1b; border: 1px solid #fecaca; }
+	.msg.ok { background: #ecfdf5; color: #065f46; border: 1px solid #a7f3d0; }
+	.hint { font-size: 0.78rem; color: #94A3B8; margin-top: 0.35rem; }
+	code { background: #f1f5f9; padding: 1px 5px; border-radius: 3px; font-size: 0.82em; }
+	.footer { margin-top: 2rem; padding-top: 1rem; border-top: 1px solid #e5e7eb; font-size: 0.78rem; color: #94A3B8; }
+</style>
+</head>
+<body>
+<main>${body}</main>
+</body>
+</html>`;
+}
+
+function formPage(opts: { error?: string } = {}): string {
+	const error = opts.error
+		? `<div class="msg err">${escapeHtml(opts.error)}</div>`
+		: "";
+	return shell(
+		"Connect Gmail — Maket",
+		`
+		<h1>Connect Gmail<span class="dot">.</span></h1>
+		<p class="lead">Paste the OAuth Desktop client JSON you downloaded from Google Cloud Console. Maket saves it locally (never in the repo) and uses it to create drafts in your Gmail. Maket never sends.</p>
+		<ol>
+			<li><a href="https://console.cloud.google.com/apis/credentials" target="_blank" rel="noopener">Open Google Cloud Console → Credentials</a></li>
+			<li>Create or open your OAuth 2.0 Client ID (type: <code>Desktop app</code>)</li>
+			<li>Click <strong>Download JSON</strong></li>
+			<li>Paste the file contents below</li>
+		</ol>
+		${error}
+		<form method="POST" action="/api/gmail/credentials" id="form">
+			<label for="credentials">Credentials JSON</label>
+			<textarea id="credentials" name="credentials" placeholder='{ "installed": { "client_id": "...", "client_secret": "...", ... } }' required></textarea>
+			<div class="hint">The file saves to <code>~/.maket/google-credentials.json</code> with owner-only permissions.</div>
+			<label class="opts">
+				<input type="checkbox" name="with_read" value="1">
+				<span>Also request inbox reading (<code>gmail.readonly</code>) — lets the AI search your mail. Default is drafts only.</span>
+			</label>
+			<button type="submit">Save credentials</button>
+		</form>
+		<div class="footer">Maket creates drafts only — it never calls Gmail's send endpoint. Source: <code>packages/server/src/tools/gmail.ts</code>.</div>
+	`,
+	);
+}
+
+function successPage(withRead: boolean): string {
+	const authUrl = `/api/gmail/auth-url${withRead ? "?with_read=1" : ""}`;
+	return shell(
+		"Credentials saved — Maket",
+		`
+		<h1>Saved<span class="dot">.</span></h1>
+		<p class="lead">Your Gmail credentials are now stored locally. Hit the button below to authorise Maket with Google, or run <code>maket_gmail action=connect${withRead ? " with_read=true" : ""}</code> from your AI assistant.</p>
+		<div class="msg ok">Credentials written to <code>$MAKET_DATA_DIR/google-credentials.json</code> (mode 0600).</div>
+		<a href="${authUrl}"><button type="button" class="secondary">Connect to Gmail →</button></a>
+		<div class="footer">You'll see Google's "unverified app" screen — that's expected for a self-hosted OSS tool. Click <strong>Advanced → Go to maket (unsafe)</strong> to proceed. The code is yours to audit.</div>
+	`,
+	);
+}
+
+function extractCredentials(raw: unknown): {
+	installed: { client_id: string; client_secret: string };
+} | null {
+	if (!raw || typeof raw !== "object") return null;
+	const obj = raw as Record<string, unknown>;
+
+	const candidate = (obj.installed ?? obj.web ?? obj) as Record<
+		string,
+		unknown
+	>;
+	const client_id = candidate?.client_id;
+	const client_secret = candidate?.client_secret;
+	if (typeof client_id !== "string" || typeof client_secret !== "string") {
+		return null;
+	}
+	return {
+		installed: {
+			client_id,
+			client_secret,
+			...(typeof candidate === "object" ? candidate : {}),
+		},
+	};
+}
+
+export function createGmailRouter({
+	config,
+	gmailClient,
+}: GmailRouterDeps): Router {
+	const router = createRouter();
+
+	// The form uses url-encoded POST so it works without JS.
+	router.use(express.urlencoded({ extended: false, limit: "64kb" }));
+
+	router.get("/setup/gmail", (_req, res) => {
+		res.type("html").send(formPage());
+	});
+
+	router.post("/api/gmail/credentials", (req, res) => {
+		const rawJson = req.body?.credentials;
+		const withRead = req.body?.with_read === "1";
+		if (typeof rawJson !== "string" || !rawJson.trim()) {
+			return res
+				.type("html")
+				.status(400)
+				.send(
+					formPage({
+						error: "Paste the JSON contents from the OAuth client you created.",
+					}),
+				);
+		}
+		let parsed: unknown;
+		try {
+			parsed = JSON.parse(rawJson);
+		} catch {
+			return res
+				.type("html")
+				.status(400)
+				.send(
+					formPage({
+						error:
+							"That didn't parse as JSON. Make sure you pasted the full file content, braces included.",
+					}),
+				);
+		}
+		const creds = extractCredentials(parsed);
+		if (!creds) {
+			return res
+				.type("html")
+				.status(400)
+				.send(
+					formPage({
+						error:
+							"Missing `client_id` or `client_secret`. Expected a Desktop app JSON with an `installed` block.",
+					}),
+				);
+		}
+		const path = join(config.DATA_DIR, "google-credentials.json");
+		mkdirSync(dirname(path), { recursive: true });
+		const tmp = `${path}.tmp`;
+		writeFileSync(tmp, JSON.stringify(creds, null, 2), { mode: 0o600 });
+		renameSync(tmp, path);
+		res.type("html").send(successPage(withRead));
+	});
+
+	router.get("/api/gmail/auth-url", async (req, res) => {
+		try {
+			const withRead = req.query.with_read === "1";
+			const redirectUri = `http://localhost:${config.PORT}/auth/google/callback`;
+			const url = await gmailClient.getAuthUrl(redirectUri, { withRead });
+			res.redirect(302, url);
+		} catch (e) {
+			const msg = e instanceof Error ? e.message : String(e);
+			res
+				.type("html")
+				.status(500)
+				.send(
+					shell(
+						"Gmail setup — error",
+						`<h1>Setup error<span class="dot">.</span></h1>
+					<div class="msg err">${escapeHtml(msg)}</div>
+					<p class="lead"><a href="/setup/gmail">Return to setup →</a></p>`,
+					),
+				);
+		}
+	});
+
+	return router;
+}

--- a/packages/server/src/routes/index.ts
+++ b/packages/server/src/routes/index.ts
@@ -16,6 +16,7 @@ const ROUTER_NAMES = [
 	"exportRouter",
 	"thumbnailRouter",
 	"oauthRouter",
+	"gmailRouter",
 	"mcpRouter",
 ] as const;
 
@@ -29,6 +30,7 @@ export { createAppRouter } from "./app.routes.js";
 export { createAssetsRouter } from "./assets.routes.js";
 export { createChartesRouter } from "./chartes.routes.js";
 export { createExportRouter } from "./export.routes.js";
+export { createGmailRouter } from "./gmail.routes.js";
 export { createMcpRouter } from "./mcp.routes.js";
 export { createOAuthRouter } from "./oauth.routes.js";
 export { createThumbnailRouter } from "./thumbnail.routes.js";

--- a/packages/server/src/services/documents.ts
+++ b/packages/server/src/services/documents.ts
@@ -115,6 +115,8 @@ export function createDocuments({ store }: DocumentsDeps): Documents {
 				locked: d.meta?.locked === true,
 				updatedAt: timestamps.get(d.name),
 				charteColor: resolveCharteColor(d.meta?.charte),
+				emailDraftUrl: d.meta?.emailDraftUrl,
+				emailDraftRole: d.meta?.emailDraftRole,
 			}));
 		},
 		all() {

--- a/packages/server/src/services/gmail-client.test.ts
+++ b/packages/server/src/services/gmail-client.test.ts
@@ -17,6 +17,19 @@ describe("createGmailClient", () => {
 		expect(a.isConnected()).toBe(true);
 		expect(b.isConnected()).toBe(false);
 	});
+
+	it("default grants: draft when connected, no read", () => {
+		const client = createGmailClient({ dataDir: "/tmp/test", env: {} });
+		expect(client.grants()).toEqual({ draft: false, read: false });
+		(client as any)._testForceConnected();
+		expect(client.grants()).toEqual({ draft: true, read: false });
+	});
+
+	it("read grant propagates when explicitly forced on", () => {
+		const client = createGmailClient({ dataDir: "/tmp/test", env: {} });
+		(client as any)._testForceConnected(true);
+		expect(client.grants()).toEqual({ draft: true, read: true });
+	});
 });
 
 describe("loadCredentials", () => {

--- a/packages/server/src/services/gmail-client.ts
+++ b/packages/server/src/services/gmail-client.ts
@@ -13,10 +13,12 @@ import { randomBytes } from "node:crypto";
 import { existsSync, readFileSync, renameSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 
-const SCOPES = [
-	"https://www.googleapis.com/auth/gmail.compose",
-	"https://www.googleapis.com/auth/gmail.readonly",
-];
+const DRAFT_SCOPE = "https://www.googleapis.com/auth/gmail.compose";
+const READ_SCOPE = "https://www.googleapis.com/auth/gmail.readonly";
+
+function buildScopes(withRead: boolean): string[] {
+	return withRead ? [DRAFT_SCOPE, READ_SCOPE] : [DRAFT_SCOPE];
+}
 
 const OAUTH_TIMEOUT_MS = 5 * 60 * 1000;
 const STATE_TTL_MS = OAUTH_TIMEOUT_MS;
@@ -54,9 +56,19 @@ export function loadCredentials(sources: CredentialSources): Credentials {
 	return keys.installed || keys.web;
 }
 
+export interface GmailGrants {
+	/** Always true when connected — drafts are mandatory. */
+	draft: boolean;
+	/** True only if the user opted into gmail.readonly at connect time. */
+	read: boolean;
+}
+
 export interface GmailClient {
 	tryRestore(): Promise<boolean>;
-	getAuthUrl(redirectUri: string): Promise<string>;
+	getAuthUrl(
+		redirectUri: string,
+		opts?: { withRead?: boolean },
+	): Promise<string>;
 	startAuth(): Promise<void>;
 	handleCallback(
 		code: string,
@@ -65,6 +77,7 @@ export interface GmailClient {
 	): Promise<string>;
 	getGmail(): Promise<any>;
 	isConnected(): boolean;
+	grants(): GmailGrants;
 }
 
 export interface GmailClientInputs {
@@ -79,6 +92,7 @@ export function createGmailClient(inputs: GmailClientInputs): GmailClient {
 
 	let auth: any = null;
 	let connected = false;
+	let readGranted = false;
 	let pendingResolve: (() => void) | null = null;
 	let pendingReject: ((err: Error) => void) | null = null;
 
@@ -115,11 +129,14 @@ export function createGmailClient(inputs: GmailClientInputs): GmailClient {
 		return true;
 	}
 
-	function saveToken(refreshToken: string): void {
+	function saveToken(refreshToken: string, withRead: boolean): void {
 		// Only the refresh token is persisted; client_id/client_secret stay in
 		// env or the credentials file. This keeps `google-token.json` from
 		// being a one-stop credential dump if the data dir leaks.
-		const payload = JSON.stringify({ refresh_token: refreshToken });
+		const payload = JSON.stringify({
+			refresh_token: refreshToken,
+			with_read: withRead,
+		});
 		const tmpPath = `${tokenPath}.tmp`;
 		writeFileSync(tmpPath, payload, { mode: 0o600 });
 		renameSync(tmpPath, tokenPath);
@@ -135,11 +152,11 @@ export function createGmailClient(inputs: GmailClientInputs): GmailClient {
 			} catch {
 				return false;
 			}
+			if (!data || typeof data !== "object") return false;
+			const payload = data as { refresh_token?: unknown; with_read?: unknown };
 			const refreshToken =
-				data &&
-				typeof data === "object" &&
-				typeof (data as { refresh_token?: unknown }).refresh_token === "string"
-					? (data as { refresh_token: string }).refresh_token
+				typeof payload.refresh_token === "string"
+					? payload.refresh_token
 					: null;
 			if (!refreshToken) return false;
 			const { google } = await import("googleapis");
@@ -151,10 +168,12 @@ export function createGmailClient(inputs: GmailClientInputs): GmailClient {
 			oauth2.setCredentials({ refresh_token: refreshToken });
 			auth = oauth2;
 			connected = true;
+			readGranted = payload.with_read === true;
 			return true;
 		},
 
-		async getAuthUrl(redirectUri: string) {
+		async getAuthUrl(redirectUri: string, opts) {
+			const withRead = opts?.withRead === true;
 			const { google } = await import("googleapis");
 			const creds = resolveCreds();
 			const oauth2 = new google.auth.OAuth2(
@@ -164,7 +183,7 @@ export function createGmailClient(inputs: GmailClientInputs): GmailClient {
 			);
 			return oauth2.generateAuthUrl({
 				access_type: "offline",
-				scope: SCOPES,
+				scope: buildScopes(withRead),
 				prompt: "consent",
 				state: newState(),
 			});
@@ -203,8 +222,14 @@ export function createGmailClient(inputs: GmailClientInputs): GmailClient {
 			);
 			const { tokens } = await oauth2.getToken(code);
 			oauth2.setCredentials(tokens);
+			// Google echoes the exact scopes the user agreed to in tokens.scope;
+			// trust that over what we asked for (user can shrink the grant in the
+			// consent screen).
+			const grantedScopes =
+				typeof tokens.scope === "string" ? tokens.scope.split(" ") : [];
+			readGranted = grantedScopes.includes(READ_SCOPE);
 			if (tokens.refresh_token) {
-				saveToken(tokens.refresh_token);
+				saveToken(tokens.refresh_token, readGranted);
 			}
 			auth = oauth2;
 			connected = true;
@@ -233,11 +258,16 @@ export function createGmailClient(inputs: GmailClientInputs): GmailClient {
 		isConnected() {
 			return connected;
 		},
+
+		grants() {
+			return { draft: connected, read: connected && readGranted };
+		},
 	};
 
 	// Testing hatch — exposed as `any` for unit tests, never used in production.
-	(client as any)._testForceConnected = () => {
+	(client as any)._testForceConnected = (withRead = false) => {
 		connected = true;
+		readGranted = withRead;
 	};
 
 	return client;

--- a/packages/server/src/services/gmail-client.ts
+++ b/packages/server/src/services/gmail-client.ts
@@ -48,8 +48,9 @@ export function loadCredentials(sources: CredentialSources): Credentials {
 	if (!path || !exists(path)) {
 		throw new Error(
 			"Google credentials not found.\n" +
-				"Option 1: Set GOOGLE_CLIENT_ID and GOOGLE_CLIENT_SECRET in .env\n" +
-				`Option 2: Place credentials JSON at ${path || "<unset>"}`,
+				"Quickest path: open http://localhost:<MAKET_PORT>/setup/gmail and paste the OAuth Desktop JSON from Google Cloud Console.\n" +
+				"Manual path: set GOOGLE_CLIENT_ID + GOOGLE_CLIENT_SECRET in .env,\n" +
+				`or drop the JSON at ${path || "<unset>"}`,
 		);
 	}
 	const keys = JSON.parse(readFile(path));

--- a/packages/server/src/tools/gmail.test.ts
+++ b/packages/server/src/tools/gmail.test.ts
@@ -27,7 +27,12 @@ type GmailApiMock = {
 };
 
 function fakeGmailClient(
-	opts: { connected?: boolean; api?: GmailApiMock } = {},
+	opts: {
+		connected?: boolean;
+		api?: GmailApiMock;
+		/** When omitted, defaults to whatever `connected` is. */
+		read?: boolean;
+	} = {},
 ): GmailClient & { api: GmailApiMock } {
 	const api: GmailApiMock = opts.api ?? {
 		users: {
@@ -50,11 +55,17 @@ function fakeGmailClient(
 		getAuthUrl: vi.fn(async () => "https://auth.example/u"),
 		startAuth: vi.fn(async () => undefined),
 		handleCallback: vi.fn(async () => "me@example.com"),
+		grants: vi.fn(() => ({
+			draft: opts.connected ?? false,
+			read: opts.read ?? opts.connected ?? false,
+		})),
 		api,
 	} as GmailClient & { api: GmailApiMock };
 }
 
-function fixture(gmailOpts: { connected?: boolean; api?: GmailApiMock } = {}) {
+function fixture(
+	gmailOpts: { connected?: boolean; api?: GmailApiMock; read?: boolean } = {},
+) {
 	const tmp = mkdtempSync(join(tmpdir(), "maket-gmail-"));
 	const store = createSQLiteStore(":memory:");
 	const documents = createDocuments({ store });
@@ -193,6 +204,32 @@ describe("maket_gmail — action=search", () => {
 	});
 });
 
+describe("maket_gmail — read scope gating", () => {
+	it("search returns next: connect with_read=true when read is not granted", async () => {
+		const { cleanup, ...deps } = fixture({ connected: true, read: false });
+		const tool = createMaketGmailTool(deps);
+		const res = await tool.handler(
+			{ action: "search", query: "is:unread" },
+			NO_EXTRA,
+		);
+		expect(res.isError).toBe(true);
+		const txt = (res.content[0] as any).text as string;
+		expect(txt).toMatch(/draft-only mode/);
+		expect(txt).toMatch(/maket_gmail action=connect with_read=true/);
+		cleanup();
+	});
+
+	it("read returns next: connect with_read=true when read is not granted", async () => {
+		const { cleanup, ...deps } = fixture({ connected: true, read: false });
+		const tool = createMaketGmailTool(deps);
+		const res = await tool.handler({ action: "read", id: "MID" }, NO_EXTRA);
+		expect(res.isError).toBe(true);
+		const txt = (res.content[0] as any).text as string;
+		expect(txt).toMatch(/maket_gmail action=connect with_read=true/);
+		cleanup();
+	});
+});
+
 describe("maket_gmail — action=read", () => {
 	it("errors when not connected", async () => {
 		const { cleanup, ...deps } = fixture({ connected: false });
@@ -319,6 +356,104 @@ describe("maket_gmail — action=draft", () => {
 		expect((res.content[0] as any).text).toMatch(/DRAFT_123/);
 		expect(gmailClient.api.users.drafts.create).toHaveBeenCalled();
 		expect(documents.resolve("mail")?.meta.emailDraftId).toBe("DRAFT_123");
+		cleanup();
+	});
+
+	it("persists a reviewable Gmail URL and role=body on the email doc", async () => {
+		const api: GmailApiMock = {
+			users: {
+				getProfile: vi.fn(async () => ({
+					data: { emailAddress: "me@example.com" },
+				})),
+				messages: {
+					list: vi.fn(),
+					get: vi.fn(),
+				},
+				drafts: {
+					create: vi.fn(async () => ({
+						data: { id: "DRAFT_9", message: { id: "MSG_X" } },
+					})),
+				},
+			},
+		};
+		const { store, documents, gmailClient, cleanup, ...deps } = fixture({
+			connected: true,
+			api,
+		});
+		store.saveDoc(makeEmailDoc("mail"));
+		documents.loadAll();
+		const tool = createMaketGmailTool({
+			store,
+			documents,
+			gmailClient,
+			...deps,
+		});
+		const res = await tool.handler(
+			{ action: "draft", doc: "mail", page: 1 },
+			NO_EXTRA,
+		);
+		const txt = (res.content[0] as any).text as string;
+		expect(txt).toMatch(/mail\.google\.com\/mail\/u\/0\/#drafts\/MSG_X/);
+		const meta = documents.resolve("mail")?.meta;
+		expect(meta?.emailDraftUrl).toBe(
+			"https://mail.google.com/mail/u/0/#drafts/MSG_X",
+		);
+		expect(meta?.emailDraftRole).toBe("body");
+		cleanup();
+	});
+
+	it("mirrors the draft URL onto attached docs with role=attachment", async () => {
+		const api: GmailApiMock = {
+			users: {
+				getProfile: vi.fn(async () => ({
+					data: { emailAddress: "me@example.com" },
+				})),
+				messages: { list: vi.fn(), get: vi.fn() },
+				drafts: {
+					create: vi.fn(async () => ({
+						data: { id: "DRAFT_42", message: { id: "MSG_42" } },
+					})),
+				},
+			},
+		};
+		const { store, documents, gmailClient, pdfService, cleanup, ...deps } =
+			fixture({ connected: true, api });
+		store.saveDoc(makeEmailDoc("mail"));
+		store.saveDoc(
+			createDocument({
+				name: "brochure",
+				canvas: {
+					format: "A4",
+					orientation: "portrait",
+					w: 210,
+					h: 297,
+					bg: "#fff",
+				},
+				pages: [{ name: "P1", elements: [], html: `<p>att</p>` }],
+			}),
+		);
+		documents.loadAll();
+		const tool = createMaketGmailTool({
+			store,
+			documents,
+			gmailClient,
+			pdfService,
+			...deps,
+		});
+		await tool.handler(
+			{
+				action: "draft",
+				doc: "mail",
+				page: 1,
+				attachments: ["brochure"],
+			},
+			NO_EXTRA,
+		);
+		const brochureMeta = documents.resolve("brochure")?.meta;
+		expect(brochureMeta?.emailDraftUrl).toBe(
+			"https://mail.google.com/mail/u/0/#drafts/MSG_42",
+		);
+		expect(brochureMeta?.emailDraftRole).toBe("attachment");
 		cleanup();
 	});
 

--- a/packages/server/src/tools/gmail.ts
+++ b/packages/server/src/tools/gmail.ts
@@ -92,15 +92,21 @@ const MaketGmailSchema = z.object({
 		.describe(
 			"For draft: PDF quality preset for attachments. Default screen (smaller).",
 		),
+	with_read: z
+		.boolean()
+		.optional()
+		.describe(
+			"For connect: also request read access (inbox search + message read). Default false — Maket only creates drafts.",
+		),
 });
 
 const DESCRIPTION = [
 	"When to use: connect Gmail, search/read mail, or create a draft from a Maket document. All actions except connect require an active OAuth session — call connect first.",
 	"",
-	"  connect — restore the refresh token if present, otherwise open the browser for OAuth consent.",
-	"  search  — list subject/from/date for messages matching a Gmail query. Capped at 50.",
-	"  read    — fetch one message by id: headers, body (3000-char truncated), attachments listing.",
-	"  draft   — compose a Gmail draft from a document page. Charte tokens resolve to literals, assets inline as base64, listed docs attach as PDFs. The draft is opened in Gmail for review — we never send automatically.",
+	"  connect — restore the refresh token if present, otherwise open the browser for OAuth consent. Pass with_read=true to also request inbox access (drafts are always granted).",
+	"  search  — list subject/from/date for messages matching a Gmail query. Capped at 50. Requires with_read=true at connect time.",
+	"  read    — fetch one message by id: headers, body (3000-char truncated), attachments listing. Requires with_read=true at connect time.",
+	"  draft   — compose a Gmail draft from a document page. Charte tokens resolve to literals, assets inline as base64, listed docs attach as PDFs. Maket never sends — the user reviews and sends from Gmail.",
 ].join("\n");
 
 export function createMaketGmailTool(deps: GmailDeps): ToolHandler {
@@ -114,7 +120,7 @@ export function createMaketGmailTool(deps: GmailDeps): ToolHandler {
 			const args = MaketGmailSchema.parse(rawArgs);
 			switch (args.action) {
 				case "connect":
-					return runConnect(deps);
+					return runConnect(args, deps);
 				case "search":
 					return runSearch(args, deps);
 				case "read":
@@ -128,17 +134,26 @@ export function createMaketGmailTool(deps: GmailDeps): ToolHandler {
 
 type Args = z.infer<typeof MaketGmailSchema>;
 
-async function runConnect(deps: GmailDeps): Promise<ToolResult> {
+async function runConnect(args: Args, deps: GmailDeps): Promise<ToolResult> {
 	const { gmailClient, config } = deps;
+	const withRead = args.with_read === true;
 	try {
 		const restored = await gmailClient.tryRestore();
 		if (restored) {
+			const grants = gmailClient.grants();
 			const gmail = await gmailClient.getGmail();
 			const profile = await gmail.users.getProfile({ userId: "me" });
-			return text(`Gmail already connected: ${profile.data.emailAddress}`);
+			// If the caller asked for read but the existing grant doesn't cover it,
+			// fall through to a fresh OAuth round so the user can consent to it.
+			if (!withRead || grants.read) {
+				const features = grants.read ? "draft + read" : "draft only";
+				return text(
+					`Gmail already connected: ${profile.data.emailAddress} (${features})`,
+				);
+			}
 		}
 		const redirectUri = `http://localhost:${config.PORT}/auth/google/callback`;
-		const authUrl = await gmailClient.getAuthUrl(redirectUri);
+		const authUrl = await gmailClient.getAuthUrl(redirectUri, { withRead });
 
 		const { execFile } = await import("node:child_process");
 		const { platform } = await import("node:os");
@@ -151,13 +166,26 @@ async function runConnect(deps: GmailDeps): Promise<ToolResult> {
 		execFile(cmd, [authUrl]);
 
 		await gmailClient.startAuth();
+		const grants = gmailClient.grants();
 		const gmail = await gmailClient.getGmail();
 		const profile = await gmail.users.getProfile({ userId: "me" });
-		return text(`Gmail connected: ${profile.data.emailAddress}`);
+		const features = grants.read ? "draft + read" : "draft only";
+		return text(`Gmail connected: ${profile.data.emailAddress} (${features})`);
 	} catch (e) {
 		const message = e instanceof Error ? e.message : String(e);
 		return text(`Gmail connection failed: ${message}`, true);
 	}
+}
+
+function requireRead(deps: GmailDeps): ToolResult | null {
+	if (deps.gmailClient.grants().read) return null;
+	return text(
+		"Gmail is connected in draft-only mode — reading is not authorized. Ask the user whether to enable inbox reading; if yes, call maket_gmail action=connect with_read=true.",
+		{
+			isError: true,
+			next: ["maket_gmail action=connect with_read=true"],
+		},
+	);
 }
 
 async function runSearch(args: Args, deps: GmailDeps): Promise<ToolResult> {
@@ -165,6 +193,8 @@ async function runSearch(args: Args, deps: GmailDeps): Promise<ToolResult> {
 	if (!args.query) return text("query is required for action=search", true);
 	if (!gmailClient.isConnected())
 		return text("Gmail not connected — call maket_gmail connect first", true);
+	const readGate = requireRead(deps);
+	if (readGate) return readGate;
 	const maxResults = Math.min(args.maxResults || 10, 50);
 	const gmail = await gmailClient.getGmail();
 	const listRes = await gmail.users.messages.list({
@@ -255,6 +285,8 @@ async function runRead(args: Args, deps: GmailDeps): Promise<ToolResult> {
 	if (!args.id) return text("id is required for action=read", true);
 	if (!gmailClient.isConnected())
 		return text("Gmail not connected — call maket_gmail connect first", true);
+	const readGate = requireRead(deps);
+	if (readGate) return readGate;
 	const gmail = await gmailClient.getGmail();
 	const detail = await gmail.users.messages.get({
 		userId: "me",
@@ -472,12 +504,32 @@ async function runDraft(args: Args, deps: GmailDeps): Promise<ToolResult> {
 		requestBody: { message: { raw } },
 	});
 	const draftId = draft.data.id || "";
+	// Gmail's draft deep link uses the underlying message id, not the draft id.
+	// Falling back to the Drafts folder if the message id is missing keeps the
+	// link useful even when the API response shape drifts.
+	const messageId = draft.data.message?.id || "";
+	const draftUrl = messageId
+		? `https://mail.google.com/mail/u/0/#drafts/${messageId}`
+		: "https://mail.google.com/mail/u/0/#drafts";
 
 	if (doc.meta) {
 		doc.meta.emailDraftId = draftId;
+		doc.meta.emailDraftUrl = draftUrl;
+		doc.meta.emailDraftRole = "body";
 		doc.meta.emailTo = to;
 		doc.meta.emailSubject = subject;
 		documents.persist(doc.name);
+	}
+
+	// Mirror the draft URL onto each attached doc so it surfaces alongside every
+	// artefact that ended up in the email, not just the body.
+	for (const name of attachmentNames) {
+		const attDoc = documents.resolveOrLoad(name);
+		if (!attDoc?.meta) continue;
+		attDoc.meta.emailDraftId = draftId;
+		attDoc.meta.emailDraftUrl = draftUrl;
+		attDoc.meta.emailDraftRole = "attachment";
+		documents.persist(attDoc.name);
 	}
 
 	const attInfo =
@@ -485,7 +537,7 @@ async function runDraft(args: Args, deps: GmailDeps): Promise<ToolResult> {
 			? ` with ${pdfAttachments.length} PDF attachment(s)`
 			: "";
 	return text(
-		`Draft created${attInfo}: ${draftId}\nTo: ${to}\nSubject: ${subject}\n\nOpen Gmail to review and send.`,
+		`Draft created${attInfo}: ${draftId}\nTo: ${to}\nSubject: ${subject}\n\nReview & send in Gmail: ${draftUrl}`,
 	);
 }
 

--- a/packages/server/src/tools/gmail.ts
+++ b/packages/server/src/tools/gmail.ts
@@ -8,7 +8,9 @@
  * `config` (ASSETS_DIR for inlining images, PORT for OAuth redirect URI).
  */
 
+import { spawn } from "node:child_process";
 import { existsSync, readFileSync } from "node:fs";
+import { platform } from "node:os";
 import { join } from "node:path";
 import { asFunction } from "awilix";
 import { z } from "zod";
@@ -134,6 +136,35 @@ export function createMaketGmailTool(deps: GmailDeps): ToolHandler {
 
 type Args = z.infer<typeof MaketGmailSchema>;
 
+/**
+ * Fire-and-forget browser launch for the OAuth consent URL. On Windows the
+ * launcher is a `cmd.exe` builtin (`start`) — spawn it through `cmd /c` with
+ * an empty title arg (`""`) so URLs containing `&` or spaces are parsed as
+ * the target, not as the window title. Errors are swallowed: the server's
+ * auth-code loop still runs, and the user can paste the URL manually if the
+ * browser can't open.
+ */
+function openBrowser(url: string): void {
+	try {
+		const child =
+			platform() === "win32"
+				? spawn("cmd", ["/c", "start", "", url], {
+						detached: true,
+						stdio: "ignore",
+					})
+				: spawn(platform() === "darwin" ? "open" : "xdg-open", [url], {
+						detached: true,
+						stdio: "ignore",
+					});
+		child.on("error", () => {
+			/* headless host or missing helper — handled by the manual paste fallback */
+		});
+		child.unref();
+	} catch {
+		/* noop — see comment above */
+	}
+}
+
 async function runConnect(args: Args, deps: GmailDeps): Promise<ToolResult> {
 	const { gmailClient, config } = deps;
 	const withRead = args.with_read === true;
@@ -155,15 +186,10 @@ async function runConnect(args: Args, deps: GmailDeps): Promise<ToolResult> {
 		const redirectUri = `http://localhost:${config.PORT}/auth/google/callback`;
 		const authUrl = await gmailClient.getAuthUrl(redirectUri, { withRead });
 
-		const { execFile } = await import("node:child_process");
-		const { platform } = await import("node:os");
-		const cmd =
-			platform() === "darwin"
-				? "open"
-				: platform() === "win32"
-					? "start"
-					: "xdg-open";
-		execFile(cmd, [authUrl]);
+		// Best-effort — if we can't launch a browser (headless box, missing
+		// xdg-open, Windows `start` quirks), the user can still copy the URL
+		// from the OAuth flow; don't let a launch failure abort connect.
+		openBrowser(authUrl);
 
 		await gmailClient.startAuth();
 		const grants = gmailClient.grants();

--- a/packages/server/src/tools/gmail.ts
+++ b/packages/server/src/tools/gmail.ts
@@ -173,6 +173,17 @@ async function runConnect(args: Args, deps: GmailDeps): Promise<ToolResult> {
 		return text(`Gmail connected: ${profile.data.emailAddress} (${features})`);
 	} catch (e) {
 		const message = e instanceof Error ? e.message : String(e);
+		const missingCreds = /credentials not found/i.test(message);
+		if (missingCreds) {
+			const setupUrl = `http://localhost:${config.PORT}/setup/gmail`;
+			return text(
+				`Gmail credentials not configured. Open ${setupUrl} to paste the OAuth Desktop JSON from Google Cloud Console, then retry maket_gmail connect.`,
+				{
+					isError: true,
+					next: [`open ${setupUrl}`, "maket_gmail action=connect"],
+				},
+			);
+		}
 		return text(`Gmail connection failed: ${message}`, true);
 	}
 }

--- a/packages/server/src/types.ts
+++ b/packages/server/src/types.ts
@@ -113,6 +113,10 @@ export interface DocSummary {
 	 * `primary` is missing), returned so the UI can render a tiny dot without
 	 * a second round-trip. Omitted when the doc has no charte. */
 	charteColor?: string;
+	/** Gmail deep link to the draft this doc is part of — surfaced in the
+	 * sidebar + workspace label when present. */
+	emailDraftUrl?: string;
+	emailDraftRole?: "body" | "attachment";
 }
 
 // ---- Charte graphique ----

--- a/packages/server/src/types.ts
+++ b/packages/server/src/types.ts
@@ -32,6 +32,8 @@ export interface DocMeta {
 	emailSubject?: string;
 	emailAttachments?: string[]; // doc IDs to attach as PDFs
 	emailDraftId?: string; // Gmail draft ID after gmail_draft
+	emailDraftUrl?: string; // Deep link to review & send the draft in Gmail
+	emailDraftRole?: "body" | "attachment"; // How this doc was included in the last draft
 }
 
 export interface Page {

--- a/packages/stdio-bridge/src/commands/gmail.ts
+++ b/packages/stdio-bridge/src/commands/gmail.ts
@@ -1,0 +1,126 @@
+/**
+ * `maket gmail` — manage the Gmail OAuth state on this machine.
+ *
+ *   status  — report whether the Desktop-app credentials file and the
+ *             refresh-token file exist under `$MAKET_DATA_DIR/`.
+ *   reset   — remove both files (after a y/N prompt unless `--force`).
+ *
+ * The server reads the same paths (`google-credentials.json`,
+ * `google-token.json`) from `config.DATA_DIR`, so this stays in sync without
+ * touching server code.
+ */
+
+import { existsSync, statSync, unlinkSync } from "node:fs";
+import { join } from "node:path";
+import { createInterface } from "node:readline";
+import { readEnv } from "./_env.ts";
+
+const GMAIL_HELP = `maket gmail — manage Gmail OAuth state on this machine
+
+  status        Show whether credentials and refresh token exist
+  reset         Remove both files after confirmation
+  reset --force Skip the y/N prompt
+
+Files live under $MAKET_DATA_DIR (default ~/.maket/):
+  google-credentials.json   — your Desktop OAuth client (client_id + secret)
+  google-token.json         — your refresh token + with_read flag
+
+See docs/gmail-setup.md for the end-to-end setup walkthrough.
+`;
+
+interface GmailFileState {
+	path: string;
+	exists: boolean;
+	mode?: string;
+}
+
+function inspect(path: string): GmailFileState {
+	if (!existsSync(path)) return { path, exists: false };
+	const mode = (statSync(path).mode & 0o777).toString(8).padStart(3, "0");
+	return { path, exists: true, mode };
+}
+
+function prompt(question: string): Promise<boolean> {
+	return new Promise((resolve) => {
+		const rl = createInterface({
+			input: process.stdin,
+			output: process.stdout,
+		});
+		rl.question(question, (answer) => {
+			rl.close();
+			resolve(/^y(es)?$/i.test(answer.trim()));
+		});
+	});
+}
+
+export async function runGmail(argv: string[]): Promise<void> {
+	const [sub = "", ...rest] = argv;
+	if (!sub || sub === "help" || sub === "--help" || sub === "-h") {
+		process.stdout.write(GMAIL_HELP);
+		return;
+	}
+	switch (sub) {
+		case "status":
+			runStatus();
+			return;
+		case "reset":
+			await runReset(rest.includes("--force"));
+			return;
+		default:
+			process.stderr.write(`maket gmail: unknown subcommand "${sub}"\n\n`);
+			process.stdout.write(GMAIL_HELP);
+			process.exitCode = 1;
+	}
+}
+
+function runStatus(): void {
+	const { dataDir } = readEnv();
+	const creds = inspect(join(dataDir, "google-credentials.json"));
+	const token = inspect(join(dataDir, "google-token.json"));
+
+	const lines: string[] = ["Gmail OAuth state"];
+	lines.push(
+		creds.exists
+			? `  ✓ credentials  ${creds.path} (mode ${creds.mode})`
+			: `  ✗ credentials  missing at ${creds.path}\n                 → paste JSON at http://localhost:<MAKET_PORT>/setup/gmail`,
+	);
+	lines.push(
+		token.exists
+			? `  ✓ refresh token ${token.path} (mode ${token.mode})`
+			: `  ✗ refresh token missing at ${token.path}\n                 → run maket_gmail action=connect`,
+	);
+	process.stdout.write(`${lines.join("\n")}\n`);
+}
+
+async function runReset(force: boolean): Promise<void> {
+	const { dataDir } = readEnv();
+	const candidates = [
+		join(dataDir, "google-credentials.json"),
+		join(dataDir, "google-token.json"),
+	];
+	const present = candidates.filter((p) => existsSync(p));
+
+	if (present.length === 0) {
+		process.stdout.write("Nothing to reset — no Gmail files found.\n");
+		return;
+	}
+
+	if (!force) {
+		process.stdout.write(
+			`About to delete:\n${present.map((p) => `  ${p}`).join("\n")}\n\n`,
+		);
+		const ok = await prompt("Proceed? [y/N] ");
+		if (!ok) {
+			process.stdout.write("Aborted.\n");
+			return;
+		}
+	}
+
+	for (const path of present) {
+		unlinkSync(path);
+		process.stdout.write(`Removed ${path}\n`);
+	}
+	process.stdout.write(
+		"Done. Re-run http://localhost:<MAKET_PORT>/setup/gmail to reconnect.\n",
+	);
+}

--- a/packages/stdio-bridge/src/commands/gmail.ts
+++ b/packages/stdio-bridge/src/commands/gmail.ts
@@ -74,7 +74,7 @@ export async function runGmail(argv: string[]): Promise<void> {
 }
 
 function runStatus(): void {
-	const { dataDir } = readEnv();
+	const { dataDir, url } = readEnv();
 	const creds = inspect(join(dataDir, "google-credentials.json"));
 	const token = inspect(join(dataDir, "google-token.json"));
 
@@ -82,7 +82,7 @@ function runStatus(): void {
 	lines.push(
 		creds.exists
 			? `  ✓ credentials  ${creds.path} (mode ${creds.mode})`
-			: `  ✗ credentials  missing at ${creds.path}\n                 → paste JSON at http://localhost:<MAKET_PORT>/setup/gmail`,
+			: `  ✗ credentials  missing at ${creds.path}\n                 → paste JSON at ${url}/setup/gmail`,
 	);
 	lines.push(
 		token.exists
@@ -93,7 +93,7 @@ function runStatus(): void {
 }
 
 async function runReset(force: boolean): Promise<void> {
-	const { dataDir } = readEnv();
+	const { dataDir, url } = readEnv();
 	const candidates = [
 		join(dataDir, "google-credentials.json"),
 		join(dataDir, "google-token.json"),
@@ -120,7 +120,5 @@ async function runReset(force: boolean): Promise<void> {
 		unlinkSync(path);
 		process.stdout.write(`Removed ${path}\n`);
 	}
-	process.stdout.write(
-		"Done. Re-run http://localhost:<MAKET_PORT>/setup/gmail to reconnect.\n",
-	);
+	process.stdout.write(`Done. Re-run ${url}/setup/gmail to reconnect.\n`);
 }

--- a/packages/stdio-bridge/src/commands/help.ts
+++ b/packages/stdio-bridge/src/commands/help.ts
@@ -21,6 +21,9 @@ COMMANDS
                         clients: claude | codex
                         flags:   --apply      write the config (default: print only)
                                  --scope=user|project   (claude only, default: user)
+  gmail <sub>         Manage Gmail OAuth state on this machine
+                        sub: status | reset [--force]
+                        see docs/gmail-setup.md for the full setup walkthrough
   help, --help        Show this help
   version, --version  Show the installed Maket version
 
@@ -34,6 +37,8 @@ EXAMPLES
   npx -y @ng-galien/maket install codex --apply
   maket start && maket open
   maket status
+  maket gmail status
+  maket gmail reset --force
   maket stop
 `;
 

--- a/packages/stdio-bridge/src/index.ts
+++ b/packages/stdio-bridge/src/index.ts
@@ -27,6 +27,7 @@ import { readFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { runBridge } from "./commands/bridge.ts";
+import { runGmail } from "./commands/gmail.ts";
 import { runHelp } from "./commands/help.ts";
 import { runInstall } from "./commands/install.ts";
 import { runLogs } from "./commands/logs.ts";
@@ -88,6 +89,9 @@ async function dispatch(argv: string[]): Promise<void> {
 			return;
 		case "install":
 			runInstall(rest);
+			return;
+		case "gmail":
+			await runGmail(rest);
 			return;
 		case "version":
 		case "--version":


### PR DESCRIPTION
## Summary

Gmail integration for the power-user path: register your own OAuth Desktop client, paste the JSON into a setup form, and Maket turns documents into Gmail drafts. No server-side credentials, no shared OAuth app, no CASA audit. Draft-only by construction — Maket never calls any Gmail send endpoint.

End-to-end validated on a live install today.

### What's in

- **Scope & auth model**
  - `maket_gmail action=connect` defaults to `gmail.compose` only. Consent screen reads *"Manage drafts and send emails"* — no "Read your Gmail" prompt.
  - `with_read=true` opts into `gmail.readonly`; `search` / `read` actions return a `next:` hint pointing at the escalation flow when not granted.
  - Server trusts the scopes Google actually echoes back, persisted in `google-token.json` alongside the refresh token.

- **Draft flow**
  - Draft returns a deep link `https://mail.google.com/mail/u/0/#drafts/<message-id>` using the draft's message id.
  - URL is stored on `doc.meta.emailDraftUrl` + `emailDraftRole: "body"|"attachment"`, mirrored onto every attached doc.
  - Client surfaces a discreet `<DraftPill>` (leading cyan dot, *"Draft ready"* / *"In draft"*, external-link glyph) in the sidebar (list + grid views) and on the workspace doc label.

- **Onboarding**
  - `GET /setup/gmail` — server-rendered form (system-ui, maket-blueprint palette). User pastes the Desktop OAuth JSON from Google Cloud Console. `POST /api/gmail/credentials` validates the `installed` / `web` / flat shapes and atomically writes `$MAKET_DATA_DIR/google-credentials.json` (mode 0600).
  - `GET /api/gmail/auth-url` — 302 redirect to Google for users who prefer the UI path over the MCP tool path.
  - If the MCP `connect` runs with no credentials, the tool returns an error pointing at `/setup/gmail`.

- **CLI**
  - `maket gmail status` — reports whether the credentials + refresh-token files exist, with file modes and next-step hints.
  - `maket gmail reset [--force]` — deletes both files after a y/N prompt. No-op when nothing is present.

- **Docs**
  - `docs/gmail-setup.md` — end-to-end English walkthrough: project creation, Gmail API enable, consent-screen wizard, test users, Desktop OAuth client, credentials handoff, expected "unverified app" screen, storage locations + permissions, Testing-mode limits, troubleshooting.
  - README Gmail section trimmed to a pointer at the new doc.
  - CLAUDE.md gains a terse "Gmail is draft-only, read is opt-in" invariants block.
  - CHANGELOG \`[Unreleased]\` updated with Changed / Added entries.

### What's out (on purpose)

- **No send.** `users.messages.send` and `users.drafts.send` are not called anywhere. You review drafts in Gmail and click Send yourself.
- **No shared OAuth app.** Each user registers their own Desktop client in their own Google Cloud project. Credentials live under `~/.maket/` with owner-only permissions.
- **No CASA audit.** App stays in Testing mode (100-user cap, 7-day refresh token rotation). Trade-off documented in `docs/gmail-setup.md`.

### Test plan

- [x] `npm run quality` passes (510 tests, lint, typecheck)
- [x] End-to-end on a real Gmail account:
  - OAuth Desktop client created in Google Cloud Console
  - Gmail API enabled, test user added
  - JSON pasted at `/setup/gmail` → credentials saved with mode 0600
  - Connect flow completes (with "unverified app" screen as expected)
  - `maket_gmail action=draft` produces a draft in Gmail (visually verified)
  - Draft with PDF attachment also works
  - `maket_gmail action=search` without read grant returns the MCP `next:` hint (not a hard error)
  - `maket gmail status` and `maket gmail reset --force` both behave as documented
- [x] CI Quality & Coverage passes on this PR