### PR TITLE
fix(server): load charte web fonts in headless renders

### DIFF
--- a/packages/server/src/lib/page-network-guard.test.ts
+++ b/packages/server/src/lib/page-network-guard.test.ts
@@ -39,11 +39,41 @@ function makePage() {
 }
 
 describe("installNetworkGuard", () => {
-	it("switches the page to offline mode when requested", async () => {
+	it.each([
+		"offline",
+		"localhost-only",
+	] satisfies NetworkGuardMode[])("installs request interception (not setOfflineMode) in %s mode", async (mode) => {
+		const page = makePage();
+		await installNetworkGuard(page as any, mode);
+		expect(page.setRequestInterception).toHaveBeenCalledWith(true);
+		expect(page.setOfflineMode).not.toHaveBeenCalled();
+	});
+
+	it.each([
+		["data:text/plain,ok", true],
+		["about:blank", true],
+		["https://fonts.googleapis.com/css2?family=Inter", true],
+		["https://fonts.gstatic.com/s/inter/v1/font.woff2", true],
+		["http://localhost:3333/assets/x.png", false],
+		["https://127.0.0.1:24842/mcp", false],
+		["http://evil.example/steal", false],
+		["https://192.168.1.1/admin", false],
+		["https://fontsXgstatic.com/font.woff2", false],
+		["not a url", false],
+	] satisfies [
+		string,
+		boolean,
+	][])("offline mode %s -> %s", async (url, allowed) => {
 		const page = makePage();
 		await installNetworkGuard(page as any, "offline");
-		expect(page.setOfflineMode).toHaveBeenCalledWith(true);
-		expect(page.setRequestInterception).not.toHaveBeenCalled();
+		const req = page.trigger(url);
+		if (allowed) {
+			expect(req.continue).toHaveBeenCalled();
+			expect(req.abort).not.toHaveBeenCalled();
+		} else {
+			expect(req.abort).toHaveBeenCalledWith("blockedbyclient");
+			expect(req.continue).not.toHaveBeenCalled();
+		}
 	});
 
 	it.each([
@@ -51,8 +81,11 @@ describe("installNetworkGuard", () => {
 		["about:blank", true],
 		["http://localhost:3333/assets/x.png", true],
 		["https://127.0.0.1:24842/mcp", true],
+		["https://fonts.googleapis.com/css2?family=Fraunces", true],
+		["https://fonts.gstatic.com/s/geist/v1/font.woff2", true],
 		["http://evil.example/steal", false],
 		["https://192.168.1.1/admin", false],
+		["https://fonts.googleapis.com.evil.example/", false],
 		["not a url", false],
 	] satisfies [
 		string,

--- a/packages/server/src/lib/page-network-guard.ts
+++ b/packages/server/src/lib/page-network-guard.ts
@@ -9,11 +9,22 @@
  *
  * `installNetworkGuard(page, mode)` neutralises this:
  *
- *  - `mode: "offline"` — nothing leaves the page. Use for paths where every
- *    asset is already inlined (PDF, thumbnail).
- *  - `mode: "localhost-only"` — only `data:` URIs and requests to `127.0.0.1`
- *    or `localhost` succeed. Use for paths that legitimately fetch from the
- *    Maket HTTP server (layout, preview).
+ *  - `mode: "offline"` — only `data:`/`about:` URIs and Google Fonts CDN
+ *    requests succeed. Use for paths that inline their assets (PDF, thumbnail)
+ *    but still need charte-declared web fonts so measured metrics match the
+ *    live preview.
+ *  - `mode: "localhost-only"` — same as offline, plus requests to `127.0.0.1`
+ *    or `localhost`. Use for paths that legitimately fetch from the Maket
+ *    HTTP server (layout check, preview snapshot).
+ *
+ * Google Fonts is whitelisted in both modes because `charteFontImport` emits
+ * `@import url('https://fonts.googleapis.com/...')` for every charte-declared
+ * family. Blocking that CDN made headless renders fall back to
+ * `serif`/`sans-serif`/`monospace` — the layout check then measured with the
+ * wrong metrics and returned "Layout OK" on pages that overflowed in the
+ * user's browser (which had loaded the real fonts). Font files are inert
+ * binaries and the URL is determined by static charte tokens, not runtime
+ * data, so allowing the CDN does not widen the exfiltration surface.
  */
 
 import type { Page } from "puppeteer";
@@ -21,16 +32,15 @@ import type { Page } from "puppeteer";
 export type NetworkGuardMode = "offline" | "localhost-only";
 
 const LOCAL_HOSTNAMES = new Set(["localhost", "127.0.0.1", "::1"]);
+const FONT_CDN_HOSTNAMES = new Set([
+	"fonts.googleapis.com",
+	"fonts.gstatic.com",
+]);
 
 export async function installNetworkGuard(
 	page: Page,
 	mode: NetworkGuardMode,
 ): Promise<void> {
-	if (mode === "offline") {
-		await page.setOfflineMode(true);
-		return;
-	}
-
 	await page.setRequestInterception(true);
 	page.on("request", (req) => {
 		const url = req.url();
@@ -41,12 +51,17 @@ export async function installNetworkGuard(
 		}
 		try {
 			const u = new URL(url);
-			if (
-				(u.protocol === "http:" || u.protocol === "https:") &&
-				LOCAL_HOSTNAMES.has(u.hostname.toLowerCase())
-			) {
-				req.continue().catch(() => {});
-				return;
+			if (u.protocol === "http:" || u.protocol === "https:") {
+				const hostname = u.hostname.toLowerCase();
+				// Google Fonts CDN is inert and required for charte font metrics.
+				if (FONT_CDN_HOSTNAMES.has(hostname)) {
+					req.continue().catch(() => {});
+					return;
+				}
+				if (mode === "localhost-only" && LOCAL_HOSTNAMES.has(hostname)) {
+					req.continue().catch(() => {});
+					return;
+				}
 			}
 		} catch {
 			// Malformed URL — block.


### PR DESCRIPTION
## Summary

- `page-network-guard` blocked `fonts.googleapis.com` in both modes, so puppeteer measured pages with `serif`/`sans-serif`/`monospace` fallbacks while the user's browser had the charte-declared Fraunces/Geist loaded
- Result: `maket_html check` returned `✓ Layout OK` on pages that visibly overflowed in the live preview (reproduced on a `DESKTOP` dashboard using the `aurora-2026` charte — FX card clipped by 24px in browser, check said OK)
- Both modes now route through `setRequestInterception` and whitelist `fonts.googleapis.com` + `fonts.gstatic.com`. `setOfflineMode` is gone — interception handler is the single source of truth
- Exfiltration surface unchanged: font URLs are driven by static charte tokens, not runtime data; WOFF2/CSS responses are inert binaries

## Validation

Re-ran `maket_html check` on the overflowing dashboard after the fix:

```
ⓘ Layout overflow — non-blocking:
  Vertical: content 799px > container 775px (+24px)
  Overflowing: fx
```

The check now points to the exact element the user had annotated in the live preview.

## Test plan

- [x] `page-network-guard.test.ts` — existing `setOfflineMode` test rewritten as a matrix over both modes; two `it.each` tables cover font CDN allowlist, localhost gating, lookalike hostnames (`fonts.googleapis.com.evil.example`, `fontsXgstatic.com`), malformed URLs
- [x] `npm run quality` green (lint 0 errors, typecheck ok, 508/508 tests across 54 files)
- [x] Manual: `maket_html check` on a Fraunces-using doc now flags the overflow the live preview shows

🤖 Generated with [Claude Code](https://claude.com/claude-code)