### PR TITLE
feat(gmail): maket_gmail action=fetch_attachment (closes #9)

### DIFF
--- a/packages/server/src/services/assets.ts
+++ b/packages/server/src/services/assets.ts
@@ -33,7 +33,14 @@ const MIME_MAP: Record<string, string> = {
 	".gif": "image/gif",
 };
 
-const IMAGE_EXTS = new Set([".png", ".jpg", ".jpeg", ".svg", ".webp", ".gif"]);
+export const IMAGE_EXTS = new Set([
+	".png",
+	".jpg",
+	".jpeg",
+	".svg",
+	".webp",
+	".gif",
+]);
 
 const MAX_PX = 4000;
 const THUMB_PX = 400;

--- a/packages/server/src/tools/gmail.test.ts
+++ b/packages/server/src/tools/gmail.test.ts
@@ -1,8 +1,15 @@
-import { mkdtempSync, rmSync } from "node:fs";
+import {
+	existsSync,
+	mkdirSync,
+	mkdtempSync,
+	readFileSync,
+	rmSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { describe, expect, it, vi } from "vitest";
 import { createAssetsService } from "../services/assets.js";
+import { createBus } from "../services/bus.js";
 import type { Config } from "../services/config.js";
 import { createDocuments } from "../services/documents.js";
 import type { GmailClient } from "../services/gmail-client.js";
@@ -19,6 +26,9 @@ type GmailApiMock = {
 		messages: {
 			list: ReturnType<typeof vi.fn>;
 			get: ReturnType<typeof vi.fn>;
+			attachments: {
+				get: ReturnType<typeof vi.fn>;
+			};
 		};
 		drafts: {
 			create: ReturnType<typeof vi.fn>;
@@ -42,6 +52,9 @@ function fakeGmailClient(
 			messages: {
 				list: vi.fn(async () => ({ data: { messages: [] } })),
 				get: vi.fn(async () => ({ data: { payload: { headers: [] } } })),
+				attachments: {
+					get: vi.fn(async () => ({ data: { size: 0, data: "" } })),
+				},
 			},
 			drafts: {
 				create: vi.fn(async () => ({ data: { id: "DRAFT_123" } })),
@@ -76,8 +89,15 @@ function fixture(
 			pageCount: 1,
 		})),
 	};
-	const config = { ASSETS_DIR: tmp } as unknown as Config;
-	const assets = createAssetsService({ assetsDir: tmp });
+	const assetsDir = join(tmp, "assets");
+	const dataDir = tmp;
+	mkdirSync(assetsDir, { recursive: true });
+	const config = {
+		ASSETS_DIR: assetsDir,
+		DATA_DIR: dataDir,
+	} as unknown as Config;
+	const assets = createAssetsService({ assetsDir });
+	const bus = createBus();
 	return {
 		store,
 		documents,
@@ -85,6 +105,8 @@ function fixture(
 		pdfService,
 		config,
 		assets,
+		bus,
+		tmp,
 		cleanup: () => {
 			store.close();
 			rmSync(tmp, { recursive: true, force: true });
@@ -186,6 +208,7 @@ describe("maket_gmail — action=search", () => {
 							},
 						},
 					})),
+					attachments: { get: vi.fn() },
 				},
 				drafts: { create: vi.fn() },
 			},
@@ -270,6 +293,7 @@ describe("maket_gmail — action=read", () => {
 							},
 						},
 					})),
+					attachments: { get: vi.fn() },
 				},
 				drafts: { create: vi.fn() },
 			},
@@ -368,6 +392,7 @@ describe("maket_gmail — action=draft", () => {
 				messages: {
 					list: vi.fn(),
 					get: vi.fn(),
+					attachments: { get: vi.fn() },
 				},
 				drafts: {
 					create: vi.fn(async () => ({
@@ -408,7 +433,11 @@ describe("maket_gmail — action=draft", () => {
 				getProfile: vi.fn(async () => ({
 					data: { emailAddress: "me@example.com" },
 				})),
-				messages: { list: vi.fn(), get: vi.fn() },
+				messages: {
+					list: vi.fn(),
+					get: vi.fn(),
+					attachments: { get: vi.fn() },
+				},
 				drafts: {
 					create: vi.fn(async () => ({
 						data: { id: "DRAFT_42", message: { id: "MSG_42" } },
@@ -503,6 +532,310 @@ describe("maket_gmail — action=draft", () => {
 		).toString();
 		expect(mime).toMatch(/multipart\/mixed/);
 		expect(mime).toMatch(/filename="brochure\.pdf"/);
+		cleanup();
+	});
+});
+
+describe("maket_gmail — action=fetch_attachment", () => {
+	// A minimal 1×1 transparent PNG — passes magic-byte validation and Jimp
+	// accepts it, so the happy-path test exercises optimize() + saveAsset().
+	const TINY_PNG = Buffer.from(
+		"iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII=",
+		"base64",
+	);
+
+	function makePayload(
+		filename: string,
+		mimeType: string,
+		attachmentId: string,
+		size: number,
+	) {
+		return {
+			filename,
+			mimeType,
+			body: { attachmentId, size },
+		};
+	}
+
+	function makeApi(
+		payload: object | null,
+		attachmentData: { size: number; data: string },
+	): GmailApiMock {
+		return {
+			users: {
+				getProfile: vi.fn(),
+				messages: {
+					list: vi.fn(),
+					get: vi.fn(async () => ({ data: { payload } })),
+					attachments: {
+						get: vi.fn(async () => ({ data: attachmentData })),
+					},
+				},
+				drafts: { create: vi.fn() },
+			},
+		};
+	}
+
+	it("errors when not connected", async () => {
+		const { cleanup, ...deps } = fixture({ connected: false });
+		const tool = createMaketGmailTool(deps);
+		const res = await tool.handler(
+			{ action: "fetch_attachment", id: "MID", attachmentId: "AID" },
+			NO_EXTRA,
+		);
+		expect(res.isError).toBe(true);
+		cleanup();
+	});
+
+	it("returns next: connect with_read=true when read is not granted", async () => {
+		const { cleanup, ...deps } = fixture({ connected: true, read: false });
+		const tool = createMaketGmailTool(deps);
+		const res = await tool.handler(
+			{ action: "fetch_attachment", id: "MID", attachmentId: "AID" },
+			NO_EXTRA,
+		);
+		expect(res.isError).toBe(true);
+		expect((res.content[0] as any).text).toMatch(
+			/maket_gmail action=connect with_read=true/,
+		);
+		cleanup();
+	});
+
+	it("errors when id or attachmentId is missing", async () => {
+		const { cleanup, ...deps } = fixture({ connected: true });
+		const tool = createMaketGmailTool(deps);
+		const res1 = await tool.handler(
+			{ action: "fetch_attachment", attachmentId: "AID" },
+			NO_EXTRA,
+		);
+		expect(res1.isError).toBe(true);
+		const res2 = await tool.handler(
+			{ action: "fetch_attachment", id: "MID" },
+			NO_EXTRA,
+		);
+		expect(res2.isError).toBe(true);
+		expect((res2.content[0] as any).text).toMatch(/attachmentId is required/);
+		cleanup();
+	});
+
+	it("image branch: writes into ASSETS_DIR, registers an asset row, emits assets:changed", async () => {
+		const payload = makePayload(
+			"pic.png",
+			"image/png",
+			"AID-img",
+			TINY_PNG.length,
+		);
+		const api = makeApi(payload, {
+			size: TINY_PNG.length,
+			data: TINY_PNG.toString("base64url"),
+		});
+		const { cleanup, bus, store, config, ...deps } = fixture({
+			connected: true,
+			api,
+		});
+		const busSpy = vi.fn();
+		bus.on("assets:changed", busSpy);
+		const tool = createMaketGmailTool({ ...deps, bus, store, config });
+		const res = await tool.handler(
+			{ action: "fetch_attachment", id: "MID", attachmentId: "AID-img" },
+			NO_EXTRA,
+		);
+		expect(res.isError).toBeUndefined();
+		expect(existsSync(join(config.ASSETS_DIR, "pic.png"))).toBe(true);
+		// Raw bytes must NOT have leaked into <DATA_DIR>/attachments/ — the image
+		// branch owns the file.
+		expect(existsSync(join(config.DATA_DIR, "attachments", "pic.png"))).toBe(
+			false,
+		);
+		expect(store.loadAsset("pic.png")).toBeTruthy();
+		expect(busSpy).toHaveBeenCalled();
+		expect((res.content[0] as any).text).toMatch(/asset library/);
+		expect((res.content[0] as any).text).toMatch(/maket_image action=view/);
+		cleanup();
+	});
+
+	it("image branch: validation failure (wrong magic bytes) discards the file and returns an error", async () => {
+		const fake = Buffer.from("notapng");
+		const payload = makePayload(
+			"bogus.png",
+			"image/png",
+			"AID-bad",
+			fake.length,
+		);
+		const api = makeApi(payload, {
+			size: fake.length,
+			data: fake.toString("base64url"),
+		});
+		const { cleanup, bus, store, config, ...deps } = fixture({
+			connected: true,
+			api,
+		});
+		const busSpy = vi.fn();
+		bus.on("assets:changed", busSpy);
+		const tool = createMaketGmailTool({ ...deps, bus, store, config });
+		const res = await tool.handler(
+			{ action: "fetch_attachment", id: "MID", attachmentId: "AID-bad" },
+			NO_EXTRA,
+		);
+		expect(res.isError).toBe(true);
+		expect((res.content[0] as any).text).toMatch(/rejected/);
+		expect(existsSync(join(config.ASSETS_DIR, "bogus.png"))).toBe(false);
+		expect(store.loadAsset("bogus.png")).toBeNull();
+		expect(busSpy).not.toHaveBeenCalled();
+		cleanup();
+	});
+
+	it("non-image branch: writes to <DATA_DIR>/attachments, skips the asset library", async () => {
+		const pdfBytes = Buffer.from("%PDF-1.4\n%fake\n");
+		const payload = makePayload(
+			"invoice.pdf",
+			"application/pdf",
+			"AID-pdf",
+			pdfBytes.length,
+		);
+		const api = makeApi(payload, {
+			size: pdfBytes.length,
+			data: pdfBytes.toString("base64url"),
+		});
+		const { cleanup, bus, store, config, ...deps } = fixture({
+			connected: true,
+			api,
+		});
+		const busSpy = vi.fn();
+		bus.on("assets:changed", busSpy);
+		const tool = createMaketGmailTool({ ...deps, bus, store, config });
+		const res = await tool.handler(
+			{ action: "fetch_attachment", id: "MID", attachmentId: "AID-pdf" },
+			NO_EXTRA,
+		);
+		expect(res.isError).toBeUndefined();
+		const saved = join(config.DATA_DIR, "attachments", "invoice.pdf");
+		expect(existsSync(saved)).toBe(true);
+		expect(readFileSync(saved).toString()).toBe(pdfBytes.toString());
+		expect(store.loadAsset("invoice.pdf")).toBeNull();
+		expect(busSpy).not.toHaveBeenCalled();
+		expect(existsSync(join(config.ASSETS_DIR, "invoice.pdf"))).toBe(false);
+		cleanup();
+	});
+
+	it("refuses to overwrite an existing non-image file unless overwrite=true", async () => {
+		const bytes = Buffer.from("v1");
+		const payload = makePayload(
+			"note.txt",
+			"text/plain",
+			"AID-note",
+			bytes.length,
+		);
+		const api = makeApi(payload, {
+			size: bytes.length,
+			data: bytes.toString("base64url"),
+		});
+		const { cleanup, config, ...deps } = fixture({ connected: true, api });
+		const tool = createMaketGmailTool({ ...deps, config });
+		const first = await tool.handler(
+			{ action: "fetch_attachment", id: "MID", attachmentId: "AID-note" },
+			NO_EXTRA,
+		);
+		expect(first.isError).toBeUndefined();
+		const second = await tool.handler(
+			{ action: "fetch_attachment", id: "MID", attachmentId: "AID-note" },
+			NO_EXTRA,
+		);
+		expect(second.isError).toBe(true);
+		expect((second.content[0] as any).text).toMatch(/already saved/);
+		const third = await tool.handler(
+			{
+				action: "fetch_attachment",
+				id: "MID",
+				attachmentId: "AID-note",
+				overwrite: true,
+			},
+			NO_EXTRA,
+		);
+		expect(third.isError).toBeUndefined();
+		cleanup();
+	});
+
+	it("refuses to overwrite an existing image asset unless overwrite=true", async () => {
+		const payload = makePayload(
+			"pic.png",
+			"image/png",
+			"AID-img",
+			TINY_PNG.length,
+		);
+		const api = makeApi(payload, {
+			size: TINY_PNG.length,
+			data: TINY_PNG.toString("base64url"),
+		});
+		const { cleanup, config, ...deps } = fixture({ connected: true, api });
+		const tool = createMaketGmailTool({ ...deps, config });
+		const first = await tool.handler(
+			{ action: "fetch_attachment", id: "MID", attachmentId: "AID-img" },
+			NO_EXTRA,
+		);
+		expect(first.isError).toBeUndefined();
+		const second = await tool.handler(
+			{ action: "fetch_attachment", id: "MID", attachmentId: "AID-img" },
+			NO_EXTRA,
+		);
+		expect(second.isError).toBe(true);
+		expect((second.content[0] as any).text).toMatch(/already exists/i);
+		cleanup();
+	});
+
+	it("rejects attachments whose declared size exceeds the 35 MB cap", async () => {
+		const payload = makePayload(
+			"huge.bin",
+			"application/octet-stream",
+			"AID-huge",
+			99 * 1024 * 1024,
+		);
+		const api = makeApi(payload, { size: 99 * 1024 * 1024, data: "" });
+		const { cleanup, ...deps } = fixture({ connected: true, api });
+		const tool = createMaketGmailTool(deps);
+		const res = await tool.handler(
+			{ action: "fetch_attachment", id: "MID", attachmentId: "AID-huge" },
+			NO_EXTRA,
+		);
+		expect(res.isError).toBe(true);
+		expect((res.content[0] as any).text).toMatch(/too large/);
+		cleanup();
+	});
+
+	it("errors clearly when the attachment id is not present on the message", async () => {
+		const api = makeApi({ parts: [] }, { size: 0, data: "" });
+		const { cleanup, ...deps } = fixture({ connected: true, api });
+		const tool = createMaketGmailTool(deps);
+		const res = await tool.handler(
+			{ action: "fetch_attachment", id: "MID", attachmentId: "AID-missing" },
+			NO_EXTRA,
+		);
+		expect(res.isError).toBe(true);
+		expect((res.content[0] as any).text).toMatch(/not found/);
+		cleanup();
+	});
+
+	it("sanitizes filenames so non-image writes stay inside <DATA_DIR>/attachments", async () => {
+		const bytes = Buffer.from("x");
+		const api = makeApi(null, {
+			size: bytes.length,
+			data: bytes.toString("base64url"),
+		});
+		const { cleanup, config, ...deps } = fixture({ connected: true, api });
+		const tool = createMaketGmailTool({ ...deps, config });
+		const res = await tool.handler(
+			{
+				action: "fetch_attachment",
+				id: "MID",
+				attachmentId: "AID-esc",
+				filename: "../../etc/passwd",
+			},
+			NO_EXTRA,
+		);
+		expect(res.isError).toBeUndefined();
+		const txt = (res.content[0] as any).text as string;
+		expect(txt).toContain(join(config.DATA_DIR, "attachments"));
+		expect(txt).not.toMatch(/\.\.\//);
 		cleanup();
 	});
 });

--- a/packages/server/src/tools/gmail.test.ts
+++ b/packages/server/src/tools/gmail.test.ts
@@ -802,6 +802,50 @@ describe("maket_gmail — action=fetch_attachment", () => {
 		cleanup();
 	});
 
+	it("rejects when Gmail omits or malforms the `size` field", async () => {
+		const payload = makePayload(
+			"weird.bin",
+			"application/octet-stream",
+			"AID-weird",
+			0,
+		);
+		const api = makeApi(payload, {
+			size: "not-a-number",
+			data: "AA==",
+		} as unknown as { size: number; data: string });
+		const { cleanup, ...deps } = fixture({ connected: true, api });
+		const tool = createMaketGmailTool(deps);
+		const res = await tool.handler(
+			{ action: "fetch_attachment", id: "MID", attachmentId: "AID-weird" },
+			NO_EXTRA,
+		);
+		expect(res.isError).toBe(true);
+		expect((res.content[0] as any).text).toMatch(/invalid attachment size/);
+		cleanup();
+	});
+
+	it("rejects via the base64 length estimate when the payload itself is oversized", async () => {
+		// A dishonest declared size + a gigantic base64 payload: the pre-decode
+		// estimate must reject before we allocate a huge Buffer.
+		const payload = makePayload(
+			"bloat.bin",
+			"application/octet-stream",
+			"AID-bloat",
+			10,
+		);
+		const bigB64 = "A".repeat(60 * 1024 * 1024);
+		const api = makeApi(payload, { size: 10, data: bigB64 });
+		const { cleanup, ...deps } = fixture({ connected: true, api });
+		const tool = createMaketGmailTool(deps);
+		const res = await tool.handler(
+			{ action: "fetch_attachment", id: "MID", attachmentId: "AID-bloat" },
+			NO_EXTRA,
+		);
+		expect(res.isError).toBe(true);
+		expect((res.content[0] as any).text).toMatch(/too large/);
+		cleanup();
+	});
+
 	it("errors clearly when the attachment id is not present on the message", async () => {
 		const api = makeApi({ parts: [] }, { size: 0, data: "" });
 		const { cleanup, ...deps } = fixture({ connected: true, api });

--- a/packages/server/src/tools/gmail.ts
+++ b/packages/server/src/tools/gmail.ts
@@ -508,10 +508,20 @@ async function runFetchAttachment(
 			`Attachment too large (${n} bytes) — limit is ${MAX_ATTACHMENT_BYTES} bytes`,
 			true,
 		);
-	const declaredSize = typeof res.data.size === "number" ? res.data.size : 0;
-	// Declared size check rejects before we pay the decode cost; the second
-	// check after decode defends against a dishonest `size` field.
+	const declaredSize = res.data.size;
+	if (
+		typeof declaredSize !== "number" ||
+		!Number.isFinite(declaredSize) ||
+		declaredSize < 0
+	)
+		return text("Gmail returned an invalid attachment size", true);
 	if (declaredSize > MAX_ATTACHMENT_BYTES) return tooLarge(declaredSize);
+	// Reject via the base64url payload length too — this upper-bounds the
+	// decoded size without allocating, so a dishonest `size` field can't get
+	// us to allocate an oversized Buffer.
+	const estimatedDecoded = Math.floor((b64.length * 3) / 4);
+	if (estimatedDecoded > MAX_ATTACHMENT_BYTES)
+		return tooLarge(estimatedDecoded);
 	const buffer = Buffer.from(b64, "base64url");
 	if (buffer.length > MAX_ATTACHMENT_BYTES) return tooLarge(buffer.length);
 

--- a/packages/server/src/tools/gmail.ts
+++ b/packages/server/src/tools/gmail.ts
@@ -1,23 +1,27 @@
 /**
  * gmail pack — maket_gmail (compound).
  *
- * Compound dispatch: connect, search, read, draft.
+ * Compound dispatch: connect, search, read, fetch_attachment, draft.
  *
- * Deps: `documents` (email doc lookup), `store` (attachment docs, charte),
- * `gmailClient` (OAuth + API), `pdfService` (render PDF attachments),
- * `config` (ASSETS_DIR for inlining images, PORT for OAuth redirect URI).
+ * Deps: `documents` (email doc lookup), `store` (attachment docs, charte,
+ * asset rows), `gmailClient` (OAuth + API), `pdfService` (render PDF
+ * attachments), `config` (ASSETS_DIR for inlining images, DATA_DIR for the
+ * non-image attachments drop, PORT for OAuth redirect URI), `assets`
+ * (filesystem helpers when importing image attachments into the library),
+ * `bus` (asset-changed broadcast when an image lands in the library).
  */
 
 import { spawn } from "node:child_process";
-import { existsSync, readFileSync } from "node:fs";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { platform } from "node:os";
-import { join } from "node:path";
+import { extname, join, resolve, sep } from "node:path";
 import { asFunction } from "awilix";
 import { z } from "zod";
 import type { ToolHandler, ToolResult } from "../core/container.js";
 import type { ToolPack } from "../core/tool-pack.js";
 import { parseCharteVars } from "../lib/charte-css.js";
-import type { AssetsService } from "../services/assets.js";
+import { type AssetsService, IMAGE_EXTS } from "../services/assets.js";
+import type { Bus } from "../services/bus.js";
 import type { Config } from "../services/config.js";
 import type { Documents } from "../services/documents.js";
 import type { GmailClient } from "../services/gmail-client.js";
@@ -32,11 +36,23 @@ export interface GmailDeps {
 	pdfService: PdfService;
 	config: Config;
 	assets: AssetsService;
+	bus: Bus;
 }
 
 type GmailPayload = any;
 
-const ActionSchema = z.enum(["connect", "search", "read", "draft"]);
+const ActionSchema = z.enum([
+	"connect",
+	"search",
+	"read",
+	"draft",
+	"fetch_attachment",
+]);
+
+// Gmail caps user attachments at 25 MB; we leave headroom for protocol
+// overhead and uncommon >25 MB attachments delivered via drive.google.com
+// CIDs. 35 MB is the ceiling we refuse to decode into memory.
+const MAX_ATTACHMENT_BYTES = 35 * 1024 * 1024;
 
 const MaketGmailSchema = z.object({
 	action: ActionSchema.describe(
@@ -88,6 +104,30 @@ const MaketGmailSchema = z.object({
 		.describe(
 			"For draft: names of other Maket docs to attach as PDFs. Falls back to doc.meta.emailAttachments.",
 		),
+	attachmentId: z
+		.string()
+		.optional()
+		.describe(
+			"For fetch_attachment: Gmail attachment id from a previous action=read call.",
+		),
+	filename: z
+		.string()
+		.optional()
+		.describe(
+			"For fetch_attachment: override the saved filename. Defaults to the name reported by Gmail.",
+		),
+	overwrite: z
+		.boolean()
+		.optional()
+		.describe(
+			"For fetch_attachment: replace an existing file (asset or non-image drop) when set. Default false.",
+		),
+	category: z
+		.string()
+		.optional()
+		.describe(
+			"For fetch_attachment (image branch only): category tag saved with the asset row. Default email-attachment.",
+		),
 	quality: z
 		.enum(["screen", "print", "hd"])
 		.optional()
@@ -103,12 +143,13 @@ const MaketGmailSchema = z.object({
 });
 
 const DESCRIPTION = [
-	"When to use: connect Gmail, search/read mail, or create a draft from a Maket document. All actions except connect require an active OAuth session — call connect first.",
+	"When to use: connect Gmail, search/read mail, download an attachment, or create a draft from a Maket document. All actions except connect require an active OAuth session — call connect first.",
 	"",
-	"  connect — restore the refresh token if present, otherwise open the browser for OAuth consent. Pass with_read=true to also request inbox access (drafts are always granted).",
-	"  search  — list subject/from/date for messages matching a Gmail query. Capped at 50. Requires with_read=true at connect time.",
-	"  read    — fetch one message by id: headers, body (3000-char truncated), attachments listing. Requires with_read=true at connect time.",
-	"  draft   — compose a Gmail draft from a document page. Charte tokens resolve to literals, assets inline as base64, listed docs attach as PDFs. Maket never sends — the user reviews and sends from Gmail.",
+	"  connect          — restore the refresh token if present, otherwise open the browser for OAuth consent. Pass with_read=true to also request inbox access (drafts are always granted).",
+	"  search           — list subject/from/date for messages matching a Gmail query. Capped at 50. Requires with_read=true at connect time.",
+	"  read             — fetch one message by id: headers, body (3000-char truncated), attachments listing. Requires with_read=true at connect time.",
+	"  fetch_attachment — download one attachment (id + attachmentId from a prior read). Images land in the Maket asset library (validated, optimized, thumbnailed, metadata row). Other files (PDF, zip, docx, …) drop into <DATA_DIR>/attachments/ untouched. Requires with_read=true at connect time.",
+	"  draft            — compose a Gmail draft from a document page. Charte tokens resolve to literals, assets inline as base64, listed docs attach as PDFs. Maket never sends — the user reviews and sends from Gmail.",
 ].join("\n");
 
 export function createMaketGmailTool(deps: GmailDeps): ToolHandler {
@@ -127,6 +168,8 @@ export function createMaketGmailTool(deps: GmailDeps): ToolHandler {
 					return runSearch(args, deps);
 				case "read":
 					return runRead(args, deps);
+				case "fetch_attachment":
+					return runFetchAttachment(args, deps);
 				case "draft":
 					return runDraft(args, deps);
 			}
@@ -352,9 +395,9 @@ async function runRead(args: Args, deps: GmailDeps): Promise<ToolResult> {
 	if (attachments.length > 0) {
 		lines.push("", `attachments (${attachments.length}):`);
 		for (const a of attachments) {
-			const size =
-				a.size < 1024 ? `${a.size}B` : `${(a.size / 1024).toFixed(0)}KB`;
-			lines.push(`  ${a.filename} (${a.mimeType}, ${size}) id:${a.id}`);
+			lines.push(
+				`  ${a.filename} (${a.mimeType}, ${formatSize(a.size)}) id:${a.id}`,
+			);
 		}
 	}
 	const maxBody = 3000;
@@ -362,6 +405,222 @@ async function runRead(args: Args, deps: GmailDeps): Promise<ToolResult> {
 	lines.push("", "body:", truncated ? body.slice(0, maxBody) : body);
 	if (truncated) lines.push(`... (${body.length - maxBody} chars remaining)`);
 	return text(lines.join("\n"));
+}
+
+function findAttachmentMeta(
+	payload: GmailPayload,
+	attachmentId: string,
+): { filename: string; mimeType: string } | null {
+	if (
+		payload.filename &&
+		payload.filename.length > 0 &&
+		payload.body?.attachmentId === attachmentId
+	) {
+		return {
+			filename: payload.filename,
+			mimeType: payload.mimeType || "application/octet-stream",
+		};
+	}
+	if (payload.parts) {
+		for (const part of payload.parts) {
+			const hit = findAttachmentMeta(part, attachmentId);
+			if (hit) return hit;
+		}
+	}
+	return null;
+}
+
+// Empty result signals an invalid name. Control chars are stripped by
+// code-point iteration to keep biome's noControlCharactersInRegex happy.
+function sanitizeFilename(raw: string): string {
+	const base = raw.replace(/[\\/]/g, "_").replace(/^\.+/, "");
+	let out = "";
+	for (const ch of base) {
+		const code = ch.charCodeAt(0);
+		if (code < 0x20 || code === 0x7f) continue;
+		if (/[<>:"|?*]/.test(ch)) {
+			out += "_";
+			continue;
+		}
+		out += ch;
+	}
+	return out.trim();
+}
+
+function formatSize(bytes: number): string {
+	return bytes < 1024 ? `${bytes}B` : `${(bytes / 1024).toFixed(0)}KB`;
+}
+
+async function runFetchAttachment(
+	args: Args,
+	deps: GmailDeps,
+): Promise<ToolResult> {
+	const { gmailClient, assets, store, bus, config } = deps;
+	if (!args.id) return text("id is required for action=fetch_attachment", true);
+	if (!args.attachmentId)
+		return text(
+			"attachmentId is required for action=fetch_attachment — run action=read on the message first to list attachment ids",
+			true,
+		);
+	if (!gmailClient.isConnected())
+		return text("Gmail not connected — call maket_gmail connect first", true);
+	const readGate = requireRead(deps);
+	if (readGate) return readGate;
+
+	const gmail = await gmailClient.getGmail();
+
+	let resolvedFilename = args.filename;
+	let mimeType = "application/octet-stream";
+	if (!resolvedFilename) {
+		const detail = await gmail.users.messages.get({
+			userId: "me",
+			id: args.id,
+			format: "full",
+		});
+		const meta = findAttachmentMeta(detail.data.payload, args.attachmentId);
+		if (!meta) {
+			return text(
+				`Attachment id "${args.attachmentId}" not found on message "${args.id}"`,
+				true,
+			);
+		}
+		resolvedFilename = meta.filename;
+		mimeType = meta.mimeType;
+	}
+
+	const safeName = sanitizeFilename(resolvedFilename);
+	if (!safeName)
+		return text(
+			"Gmail returned an empty attachment filename and none was provided",
+			true,
+		);
+
+	const res = await gmail.users.messages.attachments.get({
+		userId: "me",
+		messageId: args.id,
+		id: args.attachmentId,
+	});
+	const b64 = res.data?.data;
+	if (typeof b64 !== "string")
+		return text("Gmail returned no attachment data", true);
+	const tooLarge = (n: number) =>
+		text(
+			`Attachment too large (${n} bytes) — limit is ${MAX_ATTACHMENT_BYTES} bytes`,
+			true,
+		);
+	const declaredSize = typeof res.data.size === "number" ? res.data.size : 0;
+	// Declared size check rejects before we pay the decode cost; the second
+	// check after decode defends against a dishonest `size` field.
+	if (declaredSize > MAX_ATTACHMENT_BYTES) return tooLarge(declaredSize);
+	const buffer = Buffer.from(b64, "base64url");
+	if (buffer.length > MAX_ATTACHMENT_BYTES) return tooLarge(buffer.length);
+
+	const ext = extname(safeName).toLowerCase();
+	const isImage = IMAGE_EXTS.has(ext);
+	if (isImage) {
+		return importImageAttachment({
+			buffer,
+			filename: safeName,
+			mimeType,
+			overwrite: args.overwrite === true,
+			category: args.category || "email-attachment",
+			assets,
+			store,
+			bus,
+		});
+	}
+	return dropNonImageAttachment({
+		buffer,
+		filename: safeName,
+		mimeType,
+		overwrite: args.overwrite === true,
+		dataDir: config.DATA_DIR,
+	});
+}
+
+// On validation failure, remove() is required so a rejected image doesn't
+// linger in the library between agent turns.
+async function importImageAttachment(inputs: {
+	buffer: Buffer;
+	filename: string;
+	mimeType: string;
+	overwrite: boolean;
+	category: string;
+	assets: AssetsService;
+	store: Store;
+	bus: Bus;
+}): Promise<ToolResult> {
+	const {
+		buffer,
+		filename,
+		mimeType,
+		overwrite,
+		category,
+		assets,
+		store,
+		bus,
+	} = inputs;
+	try {
+		await assets.importBuffer(buffer, filename, overwrite);
+	} catch (e) {
+		const msg = e instanceof Error ? e.message : String(e);
+		return text(`Image import failed: ${msg}`, true);
+	}
+
+	const validation = assets.validateImageFile(filename);
+	if (!validation.valid) {
+		assets.remove(filename);
+		return text(
+			`Image import rejected: ${validation.reason}. File discarded.`,
+			true,
+		);
+	}
+
+	const optimized = await assets.optimize(filename);
+	const dims = optimized || assets.getDimensions(filename);
+	store.saveAsset({
+		filename,
+		category,
+		width: dims?.w,
+		height: dims?.h,
+	});
+	bus.emit("assets:changed", {});
+
+	const dimInfo = dims ? ` (${dims.w}×${dims.h})` : "";
+	const sizeInfo = formatSize(buffer.length);
+	return text(
+		`Imported ${filename}${dimInfo} (${mimeType}, ${sizeInfo}) into the Maket asset library.`,
+		{
+			next: [
+				`maket_image action=view filename="${filename}"`,
+				`maket_image action=meta filename="${filename}" context_token=<from view> title=... tags=[...]`,
+			],
+		},
+	);
+}
+
+function dropNonImageAttachment(inputs: {
+	buffer: Buffer;
+	filename: string;
+	mimeType: string;
+	overwrite: boolean;
+	dataDir: string;
+}): ToolResult {
+	const { buffer, filename, mimeType, overwrite, dataDir } = inputs;
+	const attDir = join(dataDir, "attachments");
+	const destAbs = resolve(join(attDir, filename));
+	if (!destAbs.startsWith(resolve(attDir) + sep))
+		return text(`Invalid filename: ${filename}`, true);
+	if (existsSync(destAbs) && !overwrite)
+		return text(
+			`Attachment already saved at ${destAbs}. Pass overwrite=true to replace.`,
+			true,
+		);
+	mkdirSync(attDir, { recursive: true });
+	writeFileSync(destAbs, buffer);
+	return text(
+		`Saved ${filename} (${mimeType}, ${formatSize(buffer.length)}) to ${destAbs}`,
+	);
 }
 
 function resolveCharteVars(html: string, charteCss: string): string {
@@ -588,6 +847,7 @@ export const gmailPack: ToolPack = {
 		"pdfService",
 		"config",
 		"assets",
+		"bus",
 	],
 	declaresTools: ["maket_gmail"],
 	register(container) {


### PR DESCRIPTION
## Summary
- Adds `fetch_attachment` as a fifth action on `maket_gmail`, routed by extension: images go through `AssetsService.importBuffer → validate → optimize → saveAsset → bus.emit(\"assets:changed\")`; non-images (PDF, zip, docx, …) land in `<DATA_DIR>/attachments/<file>` without touching the library.
- Gates behind the existing `requireRead`; enforces a 35 MB cap on decoded bytes; sanitizes filenames against traversal, Windows-reserved chars, and control chars.
- Wires a new `bus` dep on `GmailPack`, exports `IMAGE_EXTS` from `services/assets.ts` as the single source of truth, and reuses `formatSize()` across `runRead` + `runFetchAttachment`.

Closes #9.

## Test plan
- [x] `npm run quality` green (559 tests, 56 files)
- [x] Unit coverage for both branches: image happy path (asset registered + bus emit + file in ASSETS_DIR, not in attachments/), image validation failure (file discarded, no row, no emit), non-image happy path (bytes in `<DATA_DIR>/attachments/`, no asset row), overwrite semantics on both branches, oversize rejection, missing id/attachmentId, no-read-grant, filename sanitization against \`../../etc/passwd\`
- [ ] Manual smoke: `maket_gmail action=connect with_read=true` → `action=search has:attachment` → `action=read id=<MID>` → `action=fetch_attachment id=<MID> attachmentId=<AID>` on a real image and a real PDF

🤖 Generated with [Claude Code](https://claude.com/claude-code)