### PR TITLE
feat(layout): graduated tight state + actionable next hints

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,6 +70,7 @@ Always use `text(t, { isError?, next? })` from `packages/server/src/tools/_helpe
 ## Git flow & changelog
 
 - Feature branches only; `main` takes release commits directly (`chore(release): vX.Y.Z`).
+- **One feature = one branch = one issue.** Never stack unrelated work on an existing `feat/*` branch. Each new task: open a GitHub issue, branch from `origin/main` (skip local main to avoid divergence surprises), commit, let the PR close the issue.
 - No push or PR without explicit user go-ahead.
 - Conventional Commits. `npm run changelog:draft` groups commits since the last tag into an `[Unreleased]` draft — paste into `CHANGELOG.md`, cut the noise.
 - `CHANGELOG.md` follows Keep a Changelog 1.1.0 + a non-standard `Internal` bucket for CI/tests/cleanup.

--- a/README.md
+++ b/README.md
@@ -130,14 +130,16 @@ Maket exposes 11 compound MCP tools. Each one dispatches multiple actions:
 | `maket_doc` | Document lifecycle — new, list, delete, duplicate, rename, meta, export/import |
 | `maket_workspace` | Session actions — focus, state, lock, list_messages, ack_messages |
 | `maket_page` | Page structure — add, remove, rename, reorder, list |
-| `maket_canvas` | Canvas setup — format, orientation, background, text margin |
-| `maket_html` | Page content — `set` (full replace), `patch` (surgical ops by `data-id`), `get`, `check` (layout overflow) |
+| `maket_canvas` | Canvas setup — format, orientation, background, per-side print margins |
+| `maket_html` | Page content — `set` (full replace), `patch` (surgical ops by `data-id`), `get`, `check` (layout overflow / overlap / margin clearance) |
 | `maket_charte` | Brand chartes — list, view, set, delete |
 | `maket_image` | Asset library — list, view, meta, import, delete |
 | `maket_preview` | Open the live preview URL or snapshot a page to PNG |
 | `maket_mermaid` | Render a Mermaid diagram to SVG and inject it |
 | `maket_pdf` | Export a document to PDF via headless Chromium |
 | `maket_gmail` | Gmail — connect, search, read, draft |
+
+**Layout & print margins guide: [docs/layout.md](docs/layout.md)** — what the cyan safe-zone in the preview means, margin presets per use case, and prompts to ask the assistant when something looks off.
 
 ## Plugin & skills
 

--- a/docs/layout.md
+++ b/docs/layout.md
@@ -1,0 +1,49 @@
+# Layout & print margins
+
+Maket renders your document on a fixed canvas (A4, A5, poster, etc.). Whatever
+your AI assistant places on that canvas is checked against a print-safe area
+before you export to PDF or share. This page explains what you see in the live
+preview and what to ask your assistant when something looks wrong.
+
+## The cyan dashed rectangle
+
+When the document has print margins set, the live preview draws a cyan dashed
+rectangle inside the page. **This is the safe zone.** Anything inside it will
+print cleanly on any consumer printer or commercial press. Anything that
+crosses or sits outside that line risks being cut off, ending up too close to
+the edge, or being lost in the binding gutter of a printed book.
+
+The rectangle is informational only — it's there so you can spot at a glance
+whether your content lives inside the safe area.
+
+## Margin presets by use case
+
+Real-world margin conventions, with public sources you can quote when asking
+your assistant for a setup:
+
+| Use case | Top | Right | Bottom | Left | Source |
+|---|---|---|---|---|---|
+| Poster / flyer | 10mm | 10mm | 10mm | 10mm | [Lava Print artwork specs](https://lavaprint.com.au/artwork-specifications-for-print/) |
+| Paperback book (A4, left binding) | 15mm | 15mm | 15mm | 18mm | [Book Printing UK](https://info.bookprintinguk.com/en/articles/3340626-how-to-format-a4-paperback-books) |
+| Magazine | 10mm | 20mm | 10mm | 13mm | [Envato Tuts+ — Magazine layout](https://design.tutsplus.com/tutorials/how-to-create-a-professional-magazine-layout--vector-3702) |
+| Office document (Word default) | 25mm | 25mm | 25mm | 25mm | Microsoft Word default page setup |
+
+If your work doesn't fit one of these, give the assistant the millimeter values
+directly. Anything below 5mm risks getting trimmed by the printer.
+
+## Asking the assistant to fix the layout
+
+You don't need to diagnose anything yourself. Just describe what you want and
+let the assistant check and correct. A few prompts that work well:
+
+- *"Set up paperback book margins, then check the layout."*
+- *"Check the layout and fix anything that won't print cleanly."*
+- *"Run a layout check before we export to PDF, and fix what doesn't pass."*
+- *"This is a poster — use tight 10mm margins and rearrange so everything fits
+  inside the safe zone."*
+- *"My footer looks too close to the bottom edge. Fix the layout."*
+- *"Make sure nothing overlaps and nothing falls outside the safe area."*
+
+The assistant has tools to measure and patch your document. It will run the
+checks, surface any blocks that need attention, and apply the fixes — you only
+need to confirm the result in the preview.

--- a/packages/client/src/components/PageCanvas.test.tsx
+++ b/packages/client/src/components/PageCanvas.test.tsx
@@ -111,7 +111,7 @@ describe("PageCanvas toolbar interactions", () => {
 	});
 });
 
-function makeDoc(html: string, textMargin?: number): Document {
+function makeDoc(html: string, marginUniform?: number): Document {
 	return {
 		id: "id-alpha",
 		name: "alpha",
@@ -120,7 +120,16 @@ function makeDoc(html: string, textMargin?: number): Document {
 			w: 210,
 			h: 297,
 			background: "#fff",
-			...(textMargin != null ? { textMargin } : {}),
+			...(marginUniform != null
+				? {
+						margins: {
+							top: marginUniform,
+							right: marginUniform,
+							bottom: marginUniform,
+							left: marginUniform,
+						},
+					}
+				: {}),
 		},
 		pages: [{ name: "p1", elements: [], html }],
 		activePage: 0,
@@ -224,7 +233,7 @@ describe("PageCanvas rendering", () => {
 		]);
 	});
 
-	it("renders a margin guide only when canvas.textMargin > 0", () => {
+	it("renders a margin guide only when canvas.margins is set", () => {
 		const noMargin = render(
 			<PageCanvas
 				doc={makeDoc('<p data-id="a">x</p>')}

--- a/packages/client/src/components/PageCanvas.tsx
+++ b/packages/client/src/components/PageCanvas.tsx
@@ -333,7 +333,7 @@ export const PageCanvas = memo(function PageCanvas({
 		});
 	}, [pending, renderHtml]);
 
-	const margin = canvas.textMargin;
+	const margins = canvas.margins;
 
 	return (
 		<>
@@ -356,13 +356,16 @@ export const PageCanvas = memo(function PageCanvas({
 					dangerouslySetInnerHTML={{ __html: renderHtml }}
 					style={{ width: "100%", height: "100%" }}
 				/>
-				{margin != null && margin > 0 && (
+				{margins && (
 					<div
 						className="margin-guide"
 						style={{
 							position: "absolute",
-							inset: `${margin}mm`,
-							border: "0.5px dashed rgba(0,180,220,0.3)",
+							top: `${margins.top}mm`,
+							right: `${margins.right}mm`,
+							bottom: `${margins.bottom}mm`,
+							left: `${margins.left}mm`,
+							border: "1px dashed rgba(0,180,220,0.7)",
 							pointerEvents: "none",
 							zIndex: 9999,
 						}}

--- a/packages/client/src/store/types.ts
+++ b/packages/client/src/store/types.ts
@@ -1,10 +1,17 @@
+export interface Margins {
+	top: number;
+	right: number;
+	bottom: number;
+	left: number;
+}
+
 export interface Canvas {
 	w: number;
 	h: number;
 	background: string;
 	format?: string;
 	orientation?: string;
-	textMargin?: number;
+	margins?: Margins;
 	bleed?: number;
 }
 

--- a/packages/server/src/lib/page-stable-wait.ts
+++ b/packages/server/src/lib/page-stable-wait.ts
@@ -1,0 +1,36 @@
+/**
+ * Wait for a puppeteer page to reach a visually stable layout before
+ * measuring or rasterising it.
+ *
+ * `document.fonts.ready` alone is insufficient: it resolves once font files
+ * are downloaded, but Chromium still needs to decode embedded images and
+ * commit the post-swap layout pass before metrics like
+ * `Element.getBoundingClientRect()` reflect the final rendered state. An
+ * unloaded `<img>` reports `naturalHeight === 0`, the layout walker silently
+ * agrees the page fits, and the rendered PDF / screenshot disagrees with
+ * what the agent thinks shipped. See puppeteer/puppeteer#422.
+ *
+ * Procedure:
+ *  1. Run `document.fonts.ready` and `image.decode()` for every `<img>` in
+ *     parallel — they're independent (decode resolves pixel data, font
+ *     loading resolves text metrics; neither blocks the other).
+ *  2. Pump two `requestAnimationFrame` ticks. The first lets Chromium flush
+ *     pending layout invalidations triggered by the just-resolved fonts /
+ *     images; the second ensures we sample after that frame has committed.
+ */
+
+import type { Page } from "puppeteer";
+
+export const PAGE_BLOCK_SELECTOR = '[data-id="page"]';
+
+export async function waitForPageStable(page: Page): Promise<void> {
+	await page.evaluate(async () => {
+		await Promise.all([
+			document.fonts.ready,
+			...[...document.images].map((img) => img.decode().catch(() => undefined)),
+		]);
+		await new Promise<void>((resolve) =>
+			requestAnimationFrame(() => requestAnimationFrame(() => resolve())),
+		);
+	});
+}

--- a/packages/server/src/services/documents.ts
+++ b/packages/server/src/services/documents.ts
@@ -13,6 +13,7 @@
 
 import { charteFontImport, charteToCSS } from "../lib/charte-css.js";
 import type { DocSummary, Document } from "../types.js";
+import { normalizeCanvas } from "../types.js";
 import type { Store } from "./store.js";
 
 export interface Documents {
@@ -59,7 +60,10 @@ export function createDocuments({ store }: DocumentsDeps): Documents {
 
 	return {
 		loadAll() {
-			for (const d of store.loadAll()) cache.set(d.name, d);
+			for (const d of store.loadAll()) {
+				normalizeCanvas(d.canvas);
+				cache.set(d.name, d);
+			}
 		},
 		resolve(name) {
 			return cache.get(name) ?? null;
@@ -68,7 +72,10 @@ export function createDocuments({ store }: DocumentsDeps): Documents {
 			const cached = cache.get(name);
 			if (cached) return cached;
 			const loaded = store.loadOne(name);
-			if (loaded) cache.set(loaded.name, loaded);
+			if (loaded) {
+				normalizeCanvas(loaded.canvas);
+				cache.set(loaded.name, loaded);
+			}
 			return loaded ?? null;
 		},
 		persist(name) {

--- a/packages/server/src/services/layout.test.ts
+++ b/packages/server/src/services/layout.test.ts
@@ -93,7 +93,8 @@ describe("formatLayoutReport (pure)", () => {
 			{
 				overflow: false,
 				containerHeight: 1123,
-				contentHeight: 500,
+				contentHeight: 1123,
+				childMaxBottom: 500,
 			},
 			A4,
 		);
@@ -123,14 +124,15 @@ describe("formatLayoutReport (pure)", () => {
 		expect(result.overflowIds).toContain("footer");
 	});
 
-	it("flags a 'tight' page when bottom margin is below the min ship clearance", () => {
+	it("flags a 'tight' page when childMaxBottom is within the min ship clearance", () => {
 		// A4 threshold = max(10mm, 5% * 297mm) = ~14.85mm = ~56px at 96dpi.
-		// container = 1123px (canvas), content = 1118px → 5px clearance → tight.
+		// container = 1123px, childMaxBottom = 1118px → 5px clearance → tight.
 		const result = formatLayoutReport(
 			{
 				overflow: false,
 				containerHeight: 1123,
-				contentHeight: 1118,
+				contentHeight: 1123,
+				childMaxBottom: 1118,
 			},
 			A4,
 		);
@@ -140,6 +142,21 @@ describe("formatLayoutReport (pure)", () => {
 		expect(result.text).toMatch(/Tighten.*before shipping/);
 		expect(result.text).toContain("⚠");
 		expect(result.overflowIds).toEqual([]);
+	});
+
+	it("does NOT flag tight when childMaxBottom leaves comfortable clearance, even if scrollHeight equals container", () => {
+		// Regression: fixed-height root made contentHeight === containerHeight,
+		// causing tight to fire even with content occupying ~half the canvas.
+		const result = formatLayoutReport(
+			{
+				overflow: false,
+				containerHeight: 1123,
+				contentHeight: 1123,
+				childMaxBottom: 246,
+			},
+			A4,
+		);
+		expect(result.status).toBe("ok");
 	});
 
 	it("returns overflow status (not decorative ⓘ) when headless is unavailable", () => {
@@ -243,7 +260,8 @@ describe("LayoutService — measure", () => {
 			evaluate: vi.fn().mockResolvedValueOnce(undefined).mockResolvedValueOnce({
 				overflow: false,
 				containerHeight: 1123,
-				contentHeight: 1118,
+				contentHeight: 1123,
+				childMaxBottom: 1118,
 			}),
 			close: vi.fn(async () => {}),
 		};

--- a/packages/server/src/services/layout.test.ts
+++ b/packages/server/src/services/layout.test.ts
@@ -61,38 +61,92 @@ function doc(html: string): Document {
 	} as unknown as Document;
 }
 
+const A4 = { w: 210, h: 297 };
+
 describe("serverLayoutCheck (pure)", () => {
 	it("reports no overflow on a conforming layout", () => {
 		const html = `<div data-id="root" style="width:100mm;height:100mm"></div>`;
-		expect(serverLayoutCheck(html, { w: 210, h: 297 })).toMatch(/Layout OK/);
+		const result = serverLayoutCheck(html, A4);
+		expect(result.status).toBe("ok");
+		expect(result.text).toMatch(/Layout OK/);
+		expect(result.overflowIds).toEqual([]);
 	});
 
-	it("detects overflow on explicit width", () => {
+	it("detects overflow on explicit width and surfaces the offending id", () => {
 		const html = `<div data-id="big" style="width:400mm;height:50mm"></div>`;
-		const out = serverLayoutCheck(html, { w: 210, h: 297 });
-		expect(out).toMatch(/Layout overflow — non-blocking/);
-		expect(out).toMatch(/width 400mm > canvas 210mm/);
+		const result = serverLayoutCheck(html, A4);
+		expect(result.status).toBe("overflow");
+		expect(result.text).toMatch(
+			/Layout overflow — 1 issue\(s\)\. Not shippable/,
+		);
+		expect(result.text).toMatch(/width 400mm > canvas 210mm/);
+		expect(result.text).toContain("⛔");
+		expect(result.text).not.toContain("ⓘ");
+		expect(result.text).not.toMatch(/non-blocking/);
+		expect(result.overflowIds).toEqual(["big"]);
 	});
 });
 
 describe("formatLayoutReport (pure)", () => {
-	it("returns OK when no overflow flags are set", () => {
-		expect(formatLayoutReport({ overflow: false })).toMatch(/Layout OK/);
+	it("returns OK when no overflow flags are set and clearance is comfortable", () => {
+		const result = formatLayoutReport(
+			{
+				overflow: false,
+				containerHeight: 1123,
+				contentHeight: 500,
+			},
+			A4,
+		);
+		expect(result.status).toBe("ok");
+		expect(result.text).toMatch(/Layout OK/);
 	});
 
-	it("formats vertical overflow", () => {
-		const out = formatLayoutReport({
-			overflow: true,
-			overflowBy: 42,
-			contentHeight: 400,
-			containerHeight: 358,
-		});
-		expect(out).toMatch(/Layout overflow — non-blocking/);
-		expect(out).toMatch(/Vertical: content 400px > container 358px \(\+42px\)/);
+	it("formats vertical overflow with the stronger ⛔ marker", () => {
+		const result = formatLayoutReport(
+			{
+				overflow: true,
+				overflowBy: 42,
+				contentHeight: 400,
+				containerHeight: 358,
+				overflowing: ["footer"],
+			},
+			A4,
+		);
+		expect(result.status).toBe("overflow");
+		expect(result.text).toMatch(/Layout overflow — not shippable/);
+		expect(result.text).toMatch(
+			/Vertical: content 400px > container 358px \(\+42px\)/,
+		);
+		expect(result.text).toContain("⛔");
+		expect(result.text).not.toContain("ⓘ");
+		expect(result.text).not.toMatch(/non-blocking/);
+		expect(result.overflowIds).toContain("footer");
 	});
 
-	it("returns 'unavailable' on null input", () => {
-		expect(formatLayoutReport(null)).toMatch(/unavailable/);
+	it("flags a 'tight' page when bottom margin is below the min ship clearance", () => {
+		// A4 threshold = max(10mm, 5% * 297mm) = ~14.85mm = ~56px at 96dpi.
+		// container = 1123px (canvas), content = 1118px → 5px clearance → tight.
+		const result = formatLayoutReport(
+			{
+				overflow: false,
+				containerHeight: 1123,
+				contentHeight: 1118,
+			},
+			A4,
+		);
+		expect(result.status).toBe("tight");
+		expect(result.text).toMatch(/Layout tight/);
+		expect(result.text).toMatch(/bottom margin \d+mm/);
+		expect(result.text).toMatch(/Tighten.*before shipping/);
+		expect(result.text).toContain("⚠");
+		expect(result.overflowIds).toEqual([]);
+	});
+
+	it("returns overflow status (not decorative ⓘ) when headless is unavailable", () => {
+		const result = formatLayoutReport(null, A4);
+		expect(result.status).toBe("overflow");
+		expect(result.text).toMatch(/unavailable/);
+		expect(result.text).not.toContain("ⓘ");
 	});
 });
 
@@ -100,10 +154,12 @@ describe("LayoutService — measure", () => {
 	it("falls back to server check when puppeteer is unavailable", async () => {
 		const { service, cleanup } = fixture();
 		const html = `<div data-id="big" style="width:400mm;height:50mm"></div>`;
-		const report = await service.measure(doc(html), html, 0);
-		expect(report).toMatch(/Layout overflow — non-blocking/);
+		const result = await service.measure(doc(html), html, 0);
+		expect(result.status).toBe("overflow");
+		expect(result.text).toMatch(/Layout overflow/);
+		expect(result.overflowIds).toContain("big");
 		// measure() keeps the leading newline for direct concatenation.
-		expect(report.startsWith("\n")).toBe(true);
+		expect(result.text.startsWith("\n")).toBe(true);
 		cleanup();
 	});
 
@@ -118,8 +174,9 @@ describe("LayoutService — measure", () => {
 	it("returns OK on a conforming layout", async () => {
 		const { service, cleanup } = fixture();
 		const html = `<div data-id="ok" style="width:100mm;height:100mm"></div>`;
-		const report = await service.measure(doc(html), html, 0);
-		expect(report).toMatch(/Layout OK/);
+		const result = await service.measure(doc(html), html, 0);
+		expect(result.status).toBe("ok");
+		expect(result.text).toMatch(/Layout OK/);
 		cleanup();
 	});
 
@@ -133,12 +190,16 @@ describe("LayoutService — measure", () => {
 			on: vi.fn(),
 			setViewport: vi.fn(async () => {}),
 			setContent: vi.fn(async () => {}),
-			evaluate: vi.fn().mockResolvedValueOnce(undefined).mockResolvedValueOnce({
-				overflow: true,
-				containerHeight: 100,
-				contentHeight: 140,
-				overflowBy: 40,
-			}),
+			evaluate: vi
+				.fn()
+				.mockResolvedValueOnce(undefined)
+				.mockResolvedValueOnce({
+					overflow: true,
+					containerHeight: 100,
+					contentHeight: 140,
+					overflowBy: 40,
+					overflowing: ["body"],
+				}),
 			close: vi.fn(async () => {}),
 		};
 		const browser = {
@@ -153,17 +214,57 @@ describe("LayoutService — measure", () => {
 		);
 		const html = `<div data-id="root"><img data-id="img" src="/assets/hero.png"></div>`;
 
-		const report = await service.measure(doc(html), html, 0);
+		const result = await service.measure(doc(html), html, 0);
 
-		expect(report).toMatch(
+		expect(result.status).toBe("overflow");
+		expect(result.text).toMatch(
 			/Vertical: content 140px > container 100px \(\+40px\)/,
 		);
+		expect(result.overflowIds).toContain("body");
 		expect(browserLaunch).toHaveBeenCalledOnce();
 		expect(page.setContent).toHaveBeenCalledWith(
 			expect.stringContaining("http://test/assets/hero.png"),
 			{ waitUntil: "networkidle0" },
 		);
 		expect(page.close).toHaveBeenCalledOnce();
+		store.close();
+	});
+
+	it("flags tight when headless reports content just under the min bottom clearance", async () => {
+		const store = createSQLiteStore(":memory:");
+		const documents = createDocuments({ store });
+		const wsRegistry = createWsRegistry();
+		const page = {
+			setOfflineMode: vi.fn(async () => {}),
+			setRequestInterception: vi.fn(async () => {}),
+			on: vi.fn(),
+			setViewport: vi.fn(async () => {}),
+			setContent: vi.fn(async () => {}),
+			evaluate: vi.fn().mockResolvedValueOnce(undefined).mockResolvedValueOnce({
+				overflow: false,
+				containerHeight: 1123,
+				contentHeight: 1118,
+			}),
+			close: vi.fn(async () => {}),
+		};
+		const browser = {
+			connected: true,
+			on: vi.fn(),
+			newPage: vi.fn(async () => page),
+		};
+		const browserLaunch = vi.fn(async () => browser as any);
+		const service = createLayoutService(
+			{ documents, wsRegistry },
+			{ browserLaunch, getAssetBaseUrl: () => "http://test" },
+		);
+		// mm-math returns OK on a bare root, so the headless branch runs.
+		const html = `<div data-id="root" style="width:210mm;height:297mm"></div>`;
+
+		const result = await service.measure(doc(html), html, 0);
+
+		expect(result.status).toBe("tight");
+		expect(result.text).toMatch(/Layout tight/);
+		expect(result.text).toMatch(/before shipping/);
 		store.close();
 	});
 
@@ -184,10 +285,9 @@ describe("LayoutService — check", () => {
 	it("falls back to server check when puppeteer is unavailable", async () => {
 		const { service, cleanup } = fixture();
 		const html = `<div data-id="big" style="width:400mm;height:50mm"></div>`;
-		const report = await service.check(doc(html), html, 0);
-		expect(report).toMatch(/Layout overflow — non-blocking/);
-		// check() trims leading newline
-		expect(report.startsWith("\n")).toBe(false);
+		const result = await service.check(doc(html), html, 0);
+		expect(result.status).toBe("overflow");
+		expect(result.text).toMatch(/Layout overflow/);
 		cleanup();
 	});
 

--- a/packages/server/src/services/layout.test.ts
+++ b/packages/server/src/services/layout.test.ts
@@ -183,6 +183,8 @@ describe("formatLayoutReport (pure)", () => {
 			A4,
 		);
 		expect(result.status).toBe("overflow");
+		expect(result.text).toMatch(/Layout overlap — not shippable/);
+		expect(result.text).not.toMatch(/Layout overflow —/);
 		expect(result.text).toMatch(/Overlapping: a ↔ b/);
 		expect(result.text).toContain("⛔");
 		expect(result.overlapIds).toEqual(["a", "b"]);
@@ -202,6 +204,7 @@ describe("formatLayoutReport (pure)", () => {
 			A4,
 		);
 		expect(result.status).toBe("overflow");
+		expect(result.text).toMatch(/Layout overflow and overlap — not shippable/);
 		expect(result.text).toMatch(/Vertical: content 1163px/);
 		expect(result.text).toMatch(/Overflowing: foot/);
 		expect(result.text).toMatch(/Overlapping: a ↔ b/);

--- a/packages/server/src/services/layout.test.ts
+++ b/packages/server/src/services/layout.test.ts
@@ -70,6 +70,7 @@ describe("serverLayoutCheck (pure)", () => {
 		expect(result.status).toBe("ok");
 		expect(result.text).toMatch(/Layout OK/);
 		expect(result.overflowIds).toEqual([]);
+		expect(result.overlapIds).toEqual([]);
 	});
 
 	it("detects overflow on explicit width and surfaces the offending id", () => {
@@ -84,17 +85,18 @@ describe("serverLayoutCheck (pure)", () => {
 		expect(result.text).not.toContain("ⓘ");
 		expect(result.text).not.toMatch(/non-blocking/);
 		expect(result.overflowIds).toEqual(["big"]);
+		expect(result.overlapIds).toEqual([]);
 	});
 });
 
 describe("formatLayoutReport (pure)", () => {
-	it("returns OK when no overflow flags are set and clearance is comfortable", () => {
+	it("returns OK when no overflow / overlap / margin violation is reported", () => {
 		const result = formatLayoutReport(
 			{
 				overflow: false,
 				containerHeight: 1123,
 				contentHeight: 1123,
-				childMaxBottom: 500,
+				tight: { top: [], right: [], bottom: [], left: [] },
 			},
 			A4,
 		);
@@ -124,35 +126,39 @@ describe("formatLayoutReport (pure)", () => {
 		expect(result.overflowIds).toContain("footer");
 	});
 
-	it("flags a 'tight' page when childMaxBottom is within the min ship clearance", () => {
-		// A4 threshold = max(10mm, 5% * 297mm) = ~14.85mm = ~56px at 96dpi.
-		// container = 1123px, childMaxBottom = 1118px → 5px clearance → tight.
+	it("flags 'tight' per-side when blocks cross declared margin bands", () => {
 		const result = formatLayoutReport(
 			{
 				overflow: false,
 				containerHeight: 1123,
-				contentHeight: 1123,
-				childMaxBottom: 1118,
+				contentHeight: 1100,
+				tight: {
+					top: [],
+					right: ["sidebar"],
+					bottom: ["footer"],
+					left: [],
+				},
 			},
 			A4,
 		);
 		expect(result.status).toBe("tight");
 		expect(result.text).toMatch(/Layout tight/);
-		expect(result.text).toMatch(/bottom margin \d+mm/);
-		expect(result.text).toMatch(/Tighten.*before shipping/);
+		expect(result.text).toMatch(/right: sidebar/);
+		expect(result.text).toMatch(/bottom: footer/);
 		expect(result.text).toContain("⚠");
+		expect(result.tightIds).toEqual(
+			expect.arrayContaining(["sidebar", "footer"]),
+		);
 		expect(result.overflowIds).toEqual([]);
 	});
 
-	it("does NOT flag tight when childMaxBottom leaves comfortable clearance, even if scrollHeight equals container", () => {
-		// Regression: fixed-height root made contentHeight === containerHeight,
-		// causing tight to fire even with content occupying ~half the canvas.
+	it("returns OK when margins are declared but no block crosses them", () => {
 		const result = formatLayoutReport(
 			{
 				overflow: false,
 				containerHeight: 1123,
-				contentHeight: 1123,
-				childMaxBottom: 246,
+				contentHeight: 600,
+				tight: { top: [], right: [], bottom: [], left: [] },
 			},
 			A4,
 		);
@@ -164,6 +170,43 @@ describe("formatLayoutReport (pure)", () => {
 		expect(result.status).toBe("overflow");
 		expect(result.text).toMatch(/unavailable/);
 		expect(result.text).not.toContain("ⓘ");
+	});
+
+	it("flags pairwise overlap as non-shippable and surfaces both ids", () => {
+		const result = formatLayoutReport(
+			{
+				overflow: false,
+				containerHeight: 1123,
+				contentHeight: 600,
+				overlaps: [["a", "b"]],
+			},
+			A4,
+		);
+		expect(result.status).toBe("overflow");
+		expect(result.text).toMatch(/Overlapping: a ↔ b/);
+		expect(result.text).toContain("⛔");
+		expect(result.overlapIds).toEqual(["a", "b"]);
+		expect(result.overflowIds).toEqual([]);
+	});
+
+	it("co-reports overflow and overlap when both occur", () => {
+		const result = formatLayoutReport(
+			{
+				overflow: true,
+				overflowBy: 40,
+				contentHeight: 1163,
+				containerHeight: 1123,
+				overflowing: ["foot"],
+				overlaps: [["a", "b"]],
+			},
+			A4,
+		);
+		expect(result.status).toBe("overflow");
+		expect(result.text).toMatch(/Vertical: content 1163px/);
+		expect(result.text).toMatch(/Overflowing: foot/);
+		expect(result.text).toMatch(/Overlapping: a ↔ b/);
+		expect(result.overflowIds).toContain("foot");
+		expect(result.overlapIds).toEqual(["a", "b"]);
 	});
 });
 
@@ -188,12 +231,15 @@ describe("LayoutService — measure", () => {
 		cleanup();
 	});
 
-	it("returns OK on a conforming layout", async () => {
+	it("returns OK on a conforming layout but flags headless-unavailable", async () => {
 		const { service, cleanup } = fixture();
 		const html = `<div data-id="ok" style="width:100mm;height:100mm"></div>`;
 		const result = await service.measure(doc(html), html, 0);
+		// fixture's browserLaunch throws → headless unavailable → server-OK
+		// is wrapped with an explicit caveat so the agent doesn't treat ✓ as
+		// full validation (no overlap / content-overflow check ran).
 		expect(result.status).toBe("ok");
-		expect(result.text).toMatch(/Layout OK/);
+		expect(result.text).toMatch(/Layout OK \(headless unavailable/);
 		cleanup();
 	});
 
@@ -247,7 +293,7 @@ describe("LayoutService — measure", () => {
 		store.close();
 	});
 
-	it("flags tight when headless reports content just under the min bottom clearance", async () => {
+	it("flags tight per-side when headless reports a block crossing the bottom margin", async () => {
 		const store = createSQLiteStore(":memory:");
 		const documents = createDocuments({ store });
 		const wsRegistry = createWsRegistry();
@@ -257,12 +303,15 @@ describe("LayoutService — measure", () => {
 			on: vi.fn(),
 			setViewport: vi.fn(async () => {}),
 			setContent: vi.fn(async () => {}),
-			evaluate: vi.fn().mockResolvedValueOnce(undefined).mockResolvedValueOnce({
-				overflow: false,
-				containerHeight: 1123,
-				contentHeight: 1123,
-				childMaxBottom: 1118,
-			}),
+			evaluate: vi
+				.fn()
+				.mockResolvedValueOnce(undefined)
+				.mockResolvedValueOnce({
+					overflow: false,
+					containerHeight: 1123,
+					contentHeight: 1100,
+					tight: { top: [], right: [], bottom: ["footer"], left: [] },
+				}),
 			close: vi.fn(async () => {}),
 		};
 		const browser = {
@@ -275,14 +324,13 @@ describe("LayoutService — measure", () => {
 			{ documents, wsRegistry },
 			{ browserLaunch, getAssetBaseUrl: () => "http://test" },
 		);
-		// mm-math returns OK on a bare root, so the headless branch runs.
 		const html = `<div data-id="root" style="width:210mm;height:297mm"></div>`;
 
 		const result = await service.measure(doc(html), html, 0);
 
 		expect(result.status).toBe("tight");
 		expect(result.text).toMatch(/Layout tight/);
-		expect(result.text).toMatch(/before shipping/);
+		expect(result.text).toMatch(/bottom: footer/);
 		store.close();
 	});
 

--- a/packages/server/src/services/layout.ts
+++ b/packages/server/src/services/layout.ts
@@ -429,9 +429,15 @@ export function formatLayoutReport(
 				"  Elements exceed page bounds (check absolute positioning or transforms)",
 			);
 		}
+		const headline =
+			hasOverflow && hasOverlap
+				? "Layout overflow and overlap — not shippable"
+				: hasOverflow
+					? "Layout overflow — not shippable"
+					: "Layout overlap — not shippable";
 		return {
 			status: "overflow",
-			text: `\n⛔ Layout overflow — not shippable:\n${details.join("\n")}`,
+			text: `\n⛔ ${headline}:\n${details.join("\n")}`,
 			overflowIds: overflowing,
 			overlapIds,
 		};

--- a/packages/server/src/services/layout.ts
+++ b/packages/server/src/services/layout.ts
@@ -27,6 +27,10 @@ import { parseStyle } from "../lib/charte-check.js";
 import { shouldDisableSandbox } from "../lib/chromium-sandbox.js";
 import { escapeCssValue, stripStyleClose } from "../lib/css-escape.js";
 import { installNetworkGuard } from "../lib/page-network-guard.js";
+import {
+	PAGE_BLOCK_SELECTOR,
+	waitForPageStable,
+} from "../lib/page-stable-wait.js";
 import type { Document } from "../types.js";
 import type { Documents } from "./documents.js";
 import type { WsRegistry } from "./ws-registry.js";
@@ -38,7 +42,12 @@ export interface LayoutResult {
 	status: "ok" | "tight" | "overflow";
 	/** Newline-prefixed for direct concatenation; check runner trims. */
 	text: string;
+	/** Block ids that escape the canvas. */
 	overflowIds: string[];
+	/** Block ids involved in any pairwise intersection (flat unique list). */
+	overlapIds: string[];
+	/** Block ids that cross a declared margin band (flat unique list). */
+	tightIds?: string[];
 }
 
 export interface LayoutService {
@@ -137,8 +146,21 @@ body { margin: 0; padding: 0; width: ${w}mm; height: ${h}mm; overflow: hidden; b
 				height: Math.ceil(h * PX_PER_MM),
 			});
 			await page.setContent(fullHtml, { waitUntil: "networkidle0" });
-			await page.evaluate(() => document.fonts.ready);
-			return (await page.evaluate(measureInBrowser)) as LayoutReport | null;
+			await waitForPageStable(page);
+			const m = doc.canvas.margins;
+			const marginsPx = m
+				? {
+						top: m.top * PX_PER_MM,
+						right: m.right * PX_PER_MM,
+						bottom: m.bottom * PX_PER_MM,
+						left: m.left * PX_PER_MM,
+					}
+				: null;
+			return (await page.evaluate(
+				measureInBrowser,
+				PAGE_BLOCK_SELECTOR,
+				marginsPx,
+			)) as LayoutReport | null;
 		} catch {
 			return null;
 		} finally {
@@ -153,10 +175,21 @@ body { margin: 0; padding: 0; width: ${w}mm; height: ${h}mm; overflow: hidden; b
 		// Skip puppeteer when mm-math already sees overflow.
 		const serverResult = serverLayoutCheck(pageHtml, doc.canvas);
 		if (serverResult.status === "overflow") return serverResult;
-		// Headless catches content-driven overflow + the tight threshold;
-		// falls back to the server's ok when puppeteer is unavailable.
+		// Headless catches content-driven overflow, overlap, and the tight
+		// threshold; falls back to the server's ok when puppeteer is unavailable.
 		const headless = await headlessCheck(doc, pageHtml);
 		if (headless) return formatLayoutReport(headless, doc.canvas);
+		// Headless unavailable: server check passed but content-driven overflow
+		// + overlap can't be verified. Surface that explicitly so the agent
+		// doesn't treat ✓ as full validation.
+		if (serverResult.status === "ok") {
+			return {
+				status: "ok",
+				text: "\n✓ Layout OK (headless unavailable — content overflow + overlap unchecked)",
+				overflowIds: [],
+				overlapIds: [],
+			};
+		}
 		return serverResult;
 	}
 
@@ -189,18 +222,27 @@ export interface LayoutReport {
 	overflow?: boolean;
 	containerHeight?: number;
 	contentHeight?: number;
-	/**
-	 * Bottommost edge of any [data-id] descendant relative to the root's top,
-	 * in px. Used for the tight clearance check — `contentHeight` falls back
-	 * to `root.scrollHeight` which always equals `containerHeight` on a
-	 * fixed-size root, masking the real bottom margin.
-	 */
-	childMaxBottom?: number;
 	overflowBy?: number;
 	containerWidth?: number;
 	contentWidth?: number;
 	overflowByW?: number;
 	overflowing?: string[];
+	/**
+	 * Pairs of [data-id] block ids whose AABBs intersect. Skips ancestor /
+	 * descendant relations (a block "overlapping" its own contents is by
+	 * design). Empty when no pair intersects.
+	 */
+	overlaps?: [string, string][];
+	/**
+	 * Block ids that cross into a margin band (per side). Populated only when
+	 * the canvas declares `margins`; otherwise all sides are empty.
+	 */
+	tight?: {
+		top: string[];
+		right: string[];
+		bottom: string[];
+		left: string[];
+	};
 	elements?: {
 		id?: string;
 		name?: string;
@@ -310,33 +352,31 @@ export function serverLayoutCheck(
 		}
 	}
 	if (issues.length === 0) {
-		return { status: "ok", text: "\n✓ Layout OK", overflowIds: [] };
+		return {
+			status: "ok",
+			text: "\n✓ Layout OK",
+			overflowIds: [],
+			overlapIds: [],
+		};
 	}
 	return {
 		status: "overflow",
 		text: `\n⛔ Layout overflow — ${issues.length} issue(s). Not shippable.\n${issues.map((i) => `  • ${i}`).join("\n")}`,
 		overflowIds: [...overflowIds],
+		overlapIds: [],
 	};
-}
-
-/**
- * Min bottom-margin clearance before a page counts as "shippable". Scales
- * with canvas height so A5 and A4 both get a sensible guardrail without a
- * config knob.
- */
-function tightThresholdMm(canvasH: number): number {
-	return Math.max(10, canvasH * 0.05);
 }
 
 export function formatLayoutReport(
 	resp: LayoutReport | null,
-	canvas: { w: number; h: number },
+	_canvas: { w: number; h: number },
 ): LayoutResult {
 	if (!resp) {
 		return {
 			status: "overflow",
 			text: "\n⛔ Layout check unavailable",
 			overflowIds: [],
+			overlapIds: [],
 		};
 	}
 	const vOverflow = (resp.overflowBy ?? 0) > 0;
@@ -344,7 +384,19 @@ export function formatLayoutReport(
 	const hasElementOverflow =
 		(resp.overflowing?.length ?? 0) > 0 ||
 		(resp.elements?.some((el) => el.overflow) ?? false);
-	if (resp.overflow || vOverflow || hOverflow || hasElementOverflow) {
+	const overlapPairs = resp.overlaps ?? [];
+	const overlapIdSet = new Set<string>();
+	const overlapText: string[] = [];
+	for (const [a, b] of overlapPairs) {
+		if (a) overlapIdSet.add(a);
+		if (b) overlapIdSet.add(b);
+		overlapText.push(`${a} ↔ ${b}`);
+	}
+	const overlapIds = [...overlapIdSet];
+	const hasOverlap = overlapPairs.length > 0;
+	const hasOverflow =
+		resp.overflow === true || vOverflow || hOverflow || hasElementOverflow;
+	if (hasOverflow || hasOverlap) {
 		const overflowing = [
 			...new Set(
 				[
@@ -369,6 +421,9 @@ export function formatLayoutReport(
 		if (overflowing.length > 0) {
 			details.push(`  Overflowing: ${overflowing.join(", ")}`);
 		}
+		if (hasOverlap) {
+			details.push(`  Overlapping: ${overlapText.join(", ")}`);
+		}
 		if (details.length === 0) {
 			details.push(
 				"  Elements exceed page bounds (check absolute positioning or transforms)",
@@ -378,89 +433,148 @@ export function formatLayoutReport(
 			status: "overflow",
 			text: `\n⛔ Layout overflow — not shippable:\n${details.join("\n")}`,
 			overflowIds: overflowing,
+			overlapIds,
 		};
 	}
-	const containerH = resp.containerHeight ?? 0;
-	const childBottom = resp.childMaxBottom ?? 0;
-	const thresholdMm = tightThresholdMm(canvas.h);
-	const bottomMarginPx = containerH - childBottom;
-	if (
-		containerH > 0 &&
-		childBottom > 0 &&
-		bottomMarginPx < thresholdMm * PX_PER_MM
-	) {
-		const bottomMarginMm = Math.round(bottomMarginPx / PX_PER_MM);
+	const tight = resp.tight;
+	const tightSides: { side: string; ids: string[] }[] = [];
+	if (tight?.top.length) tightSides.push({ side: "top", ids: tight.top });
+	if (tight?.right.length) tightSides.push({ side: "right", ids: tight.right });
+	if (tight?.bottom.length)
+		tightSides.push({ side: "bottom", ids: tight.bottom });
+	if (tight?.left.length) tightSides.push({ side: "left", ids: tight.left });
+	if (tightSides.length > 0) {
+		const ids = [...new Set(tightSides.flatMap((s) => s.ids))];
+		const sideText = tightSides
+			.map((s) => `${s.side}: ${s.ids.join(", ")}`)
+			.join(" • ");
 		return {
 			status: "tight",
-			text: `\n⚠ Layout tight — bottom margin ${bottomMarginMm}mm (min ${Math.round(thresholdMm)}mm). Tighten or move content up before shipping.`,
+			text: `\n⚠ Layout tight — blocks cross declared margins (${sideText}). Tighten or move content inside the safe zone before shipping.`,
 			overflowIds: [],
+			overlapIds: [],
+			tightIds: ids,
 		};
 	}
-	return { status: "ok", text: "\n✓ Layout OK", overflowIds: [] };
+	return {
+		status: "ok",
+		text: "\n✓ Layout OK",
+		overflowIds: [],
+		overlapIds: [],
+	};
 }
 
-// Run inside puppeteer — has access to `document`.
-function measureInBrowser() {
-	const root = document.body.firstElementChild as HTMLElement | null;
+// Run inside puppeteer — has access to `document`. Selector + margins passed
+// in because page.evaluate ships the function source, not its closure.
+//
+// Format contract (see html.ts tool description): the agent's HTML root is
+// `<div data-id="page" style="width:Wmm;height:Hmm">…</div>` — a single block
+// declaring its own measurement zone. Falls back to firstElementChild for
+// legacy / non-canonical content.
+function measureInBrowser(
+	pageSelector: string,
+	marginsPx: {
+		top: number;
+		right: number;
+		bottom: number;
+		left: number;
+	} | null,
+) {
+	const TOLERANCE_PX = 2;
+	const root = (document.body.querySelector(pageSelector) ??
+		document.body.firstElementChild) as HTMLElement | null;
 	if (!root) return null;
 	const rootRect = root.getBoundingClientRect();
 	const containerHeight = Math.round(rootRect.height);
 	const containerWidth = Math.round(rootRect.width);
-	const elements = [...root.querySelectorAll("[data-id]")].map((node) => {
+	const blocks = [...root.querySelectorAll("[data-id]")].map((node) => {
 		const el = node as HTMLElement;
 		const rect = el.getBoundingClientRect();
 		const top = Math.round(rect.top - rootRect.top);
 		const left = Math.round(rect.left - rootRect.left);
 		const bottom = Math.round(rect.bottom - rootRect.top);
 		const right = Math.round(rect.right - rootRect.left);
-		const overflow =
-			top < -1 ||
-			left < -1 ||
-			bottom > containerHeight + 1 ||
-			right > containerWidth + 1;
 		return {
-			id: el.dataset.id,
+			el,
+			id: el.dataset.id || "",
 			name: el.dataset.name || "",
 			top,
 			left,
 			bottom,
 			right,
-			overflow,
+			overflow:
+				top < -TOLERANCE_PX ||
+				left < -TOLERANCE_PX ||
+				bottom > containerHeight + TOLERANCE_PX ||
+				right > containerWidth + TOLERANCE_PX,
 		};
 	});
-	const minTop = elements.length
-		? Math.min(0, ...elements.map((el) => el.top))
-		: 0;
-	const minLeft = elements.length
-		? Math.min(0, ...elements.map((el) => el.left))
-		: 0;
-	const maxBottom = elements.length
-		? Math.max(root.scrollHeight, ...elements.map((el) => el.bottom))
+	const minTop = blocks.length ? Math.min(0, ...blocks.map((b) => b.top)) : 0;
+	const minLeft = blocks.length ? Math.min(0, ...blocks.map((b) => b.left)) : 0;
+	const maxBottom = blocks.length
+		? Math.max(root.scrollHeight, ...blocks.map((b) => b.bottom))
 		: root.scrollHeight;
-	const maxRight = elements.length
-		? Math.max(root.scrollWidth, ...elements.map((el) => el.right))
+	const maxRight = blocks.length
+		? Math.max(root.scrollWidth, ...blocks.map((b) => b.right))
 		: root.scrollWidth;
 	const contentHeight = Math.round(maxBottom - minTop);
 	const contentWidth = Math.round(maxRight - minLeft);
-	const childMaxBottom = elements.length
-		? Math.round(Math.max(0, ...elements.map((el) => el.bottom)))
-		: 0;
-	const overflowing = elements
-		.filter((el) => el.overflow)
-		.map((el) => el.id || el.name || "")
+	const overflowing = blocks
+		.filter((b) => b.overflow)
+		.map((b) => b.id || b.name || "")
 		.filter(Boolean);
 	const overflowV = contentHeight > containerHeight;
 	const overflowH = contentWidth > containerWidth;
+	// Pairwise AABB intersection on tagged blocks. Skip ancestor/descendant
+	// relations (a block "overlapping" its own contents is by design — flex/
+	// grid containers always intersect their children). N is small (~50
+	// blocks/page → ~1250 pairs) so quadratic cost is negligible.
+	const overlaps: [string, string][] = [];
+	for (const [i, a] of blocks.entries()) {
+		if (!a.id) continue;
+		for (const b of blocks.slice(i + 1)) {
+			if (!b.id) continue;
+			if (a.el.contains(b.el) || b.el.contains(a.el)) continue;
+			const intersects =
+				a.left < b.right - TOLERANCE_PX &&
+				a.right > b.left + TOLERANCE_PX &&
+				a.top < b.bottom - TOLERANCE_PX &&
+				a.bottom > b.top + TOLERANCE_PX;
+			if (intersects) overlaps.push([a.id, b.id]);
+		}
+	}
+	const tight = { top: [], right: [], bottom: [], left: [] } as {
+		top: string[];
+		right: string[];
+		bottom: string[];
+		left: string[];
+	};
+	if (marginsPx) {
+		for (const b of blocks) {
+			if (!b.id || b.overflow) continue;
+			if (b.top < marginsPx.top - TOLERANCE_PX) tight.top.push(b.id);
+			if (b.left < marginsPx.left - TOLERANCE_PX) tight.left.push(b.id);
+			if (b.bottom > containerHeight - marginsPx.bottom + TOLERANCE_PX)
+				tight.bottom.push(b.id);
+			if (b.right > containerWidth - marginsPx.right + TOLERANCE_PX)
+				tight.right.push(b.id);
+		}
+	}
 	return {
 		overflow: overflowV || overflowH || overflowing.length > 0,
 		containerHeight,
 		contentHeight,
-		childMaxBottom,
 		overflowBy: overflowV ? contentHeight - containerHeight : 0,
 		containerWidth,
 		contentWidth,
 		overflowByW: overflowH ? contentWidth - containerWidth : 0,
 		overflowing,
-		elements,
+		overlaps,
+		tight,
+		elements: blocks.map((b) => ({
+			id: b.id,
+			name: b.name,
+			overflow: b.overflow,
+		})),
 	};
 }

--- a/packages/server/src/services/layout.ts
+++ b/packages/server/src/services/layout.ts
@@ -31,18 +31,40 @@ import type { Document } from "../types.js";
 import type { Documents } from "./documents.js";
 import type { WsRegistry } from "./ws-registry.js";
 
+/**
+ * Structured layout verdict. Services return this instead of a raw string
+ * so the tool layer can branch on `status` (e.g. emit `next:` hints on
+ * tight/overflow) without parsing text back.
+ *
+ * - `text` is newline-prefixed for direct concatenation into set/patch
+ *   responses. The check runner trims before rendering in isolation.
+ * - `overflowIds` lists the `data-id` of elements flagged by the mm-math
+ *   walker or headless measurement. Empty when status is `ok` or `tight`.
+ */
+export interface LayoutResult {
+	status: "ok" | "tight" | "overflow";
+	text: string;
+	overflowIds: string[];
+}
+
 export interface LayoutService {
 	/**
 	 * Broadcast the new page state so connected previews refresh, then return
-	 * a canvas-authoritative layout summary (newline-prefixed for direct
-	 * concatenation into tool output).
+	 * a canvas-authoritative layout verdict.
 	 */
-	measure(doc: Document, pageHtml: string, pageIdx: number): Promise<string>;
+	measure(
+		doc: Document,
+		pageHtml: string,
+		pageIdx: number,
+	): Promise<LayoutResult>;
 	/**
-	 * Return a trimmed layout summary for `maket_html check` (no leading
-	 * newline, no state broadcast).
+	 * Return a layout verdict for `maket_html check` (no state broadcast).
 	 */
-	check(doc: Document, pageHtml: string, pageIdx: number): Promise<string>;
+	check(
+		doc: Document,
+		pageHtml: string,
+		pageIdx: number,
+	): Promise<LayoutResult>;
 }
 
 export interface LayoutServiceDeps {
@@ -137,18 +159,22 @@ body { margin: 0; padding: 0; width: ${w}mm; height: ${h}mm; overflow: hidden; b
 		}
 	}
 
-	async function runMeasure(doc: Document, pageHtml: string): Promise<string> {
+	async function runMeasure(
+		doc: Document,
+		pageHtml: string,
+	): Promise<LayoutResult> {
 		// serverLayoutCheck is fast and authoritative for declared-mm dimensions
 		// (width/height > canvas, flex-row children sum, absolute overshoot).
-		// If it flags anything, report that — no need to warm puppeteer.
-		const serverReport = serverLayoutCheck(pageHtml, doc.canvas);
-		if (!/Layout OK/.test(serverReport)) return serverReport;
+		// If it flags overflow, report that — no need to warm puppeteer.
+		const serverResult = serverLayoutCheck(pageHtml, doc.canvas);
+		if (serverResult.status === "overflow") return serverResult;
 		// Otherwise fall through to headless rendering, which also catches
-		// content-driven overflow (long text, wrapping etc.) that mm-math
-		// can't see. A missing puppeteer falls back to the server's OK.
+		// content-driven overflow and the "tight" threshold (bottom margin
+		// below the min ship clearance). Missing puppeteer falls back to the
+		// server's OK.
 		const headless = await headlessCheck(doc, pageHtml);
-		if (headless) return formatLayoutReport(headless);
-		return serverReport;
+		if (headless) return formatLayoutReport(headless, doc.canvas);
+		return serverResult;
 	}
 
 	function broadcastState(doc: Document, pageIdx: number) {
@@ -170,7 +196,7 @@ body { margin: 0; padding: 0; width: ${w}mm; height: ${h}mm; overflow: hidden; b
 			return runMeasure(doc, pageHtml);
 		},
 		async check(doc, pageHtml, _pageIdx) {
-			return (await runMeasure(doc, pageHtml)).trim();
+			return runMeasure(doc, pageHtml);
 		},
 	};
 }
@@ -205,9 +231,14 @@ function parseMm(value: string | undefined): number | null {
 export function serverLayoutCheck(
 	html: string,
 	canvas: { w: number; h: number },
-): string {
+): LayoutResult {
 	const { document: dom } = parseHTML(`<html><body>${html}</body></html>`);
 	const issues: string[] = [];
+	const overflowIds = new Set<string>();
+	const flag = (id: string | null, msg: string) => {
+		issues.push(msg);
+		if (id) overflowIds.add(id);
+	};
 	for (const el of dom.body.querySelectorAll("[data-id]")) {
 		const node = el as unknown as {
 			getAttribute(name: string): string | null;
@@ -219,12 +250,14 @@ export function serverLayoutCheck(
 		const w = parseMm(props.get("width"));
 		const h = parseMm(props.get("height"));
 		if (w && w > canvas.w) {
-			issues.push(
+			flag(
+				id,
 				`[${id}] width ${w}mm > canvas ${canvas.w}mm (+${Math.round(w - canvas.w)}mm)`,
 			);
 		}
 		if (h && h > canvas.h) {
-			issues.push(
+			flag(
+				id,
 				`[${id}] height ${h}mm > canvas ${canvas.h}mm (+${Math.round(h - canvas.h)}mm)`,
 			);
 		}
@@ -265,7 +298,8 @@ export function serverLayoutCheck(
 			if (childCount > 0 && childCount === totalChildren) {
 				if (childCount > 1) childSum += gap * (childCount - 1);
 				if (childSum > innerW) {
-					issues.push(
+					flag(
+						id,
 						`[${id}] flex row children total ${Math.round(childSum)}mm > container ${Math.round(innerW)}mm (+${Math.round(childSum - innerW)}mm)`,
 					);
 				}
@@ -275,23 +309,52 @@ export function serverLayoutCheck(
 			const left = parseMm(props.get("left"));
 			const top = parseMm(props.get("top"));
 			if (left != null && w != null && left + w > canvas.w) {
-				issues.push(
+				flag(
+					id,
 					`[${id}] left(${left}mm) + width(${w}mm) = ${left + w}mm > canvas ${canvas.w}mm`,
 				);
 			}
 			if (top != null && h != null && top + h > canvas.h) {
-				issues.push(
+				flag(
+					id,
 					`[${id}] top(${top}mm) + height(${h}mm) = ${top + h}mm > canvas ${canvas.h}mm`,
 				);
 			}
 		}
 	}
-	if (issues.length === 0) return "\n✓ Layout OK";
-	return `\nⓘ Layout overflow — non-blocking (${issues.length} issue(s)):\n${issues.map((i) => `  • ${i}`).join("\n")}`;
+	if (issues.length === 0) {
+		return { status: "ok", text: "\n✓ Layout OK", overflowIds: [] };
+	}
+	return {
+		status: "overflow",
+		text: `\n⛔ Layout overflow — ${issues.length} issue(s). Not shippable.\n${issues.map((i) => `  • ${i}`).join("\n")}`,
+		overflowIds: [...overflowIds],
+	};
 }
 
-export function formatLayoutReport(resp: LayoutReport | null): string {
-	if (!resp) return "\nⓘ Layout check unavailable";
+/** px per mm at 96 DPI — `installNetworkGuard` renders at this scale. */
+const PX_PER_MM = 96 / 25.4;
+
+/**
+ * Minimum bottom-margin clearance before a page is considered "shippable".
+ * Scales with canvas height so a 148mm A5 and a 297mm A4 both get a
+ * reasonable guardrail (~10mm on A5, ~15mm on A4), without a config knob.
+ */
+function tightThresholdMm(canvasH: number): number {
+	return Math.max(10, canvasH * 0.05);
+}
+
+export function formatLayoutReport(
+	resp: LayoutReport | null,
+	canvas: { w: number; h: number },
+): LayoutResult {
+	if (!resp) {
+		return {
+			status: "overflow",
+			text: "\n⚠ Layout check unavailable",
+			overflowIds: [],
+		};
+	}
 	const overflowing = [
 		...new Set(
 			[
@@ -308,27 +371,49 @@ export function formatLayoutReport(resp: LayoutReport | null): string {
 			(resp.overflowByW ?? 0) > 0 ||
 			overflowing.length,
 	);
-	if (!hasOverflow) return "\n✓ Layout OK";
-	const details: string[] = [];
-	if ((resp.overflowBy ?? 0) > 0) {
-		details.push(
-			`  Vertical: content ${resp.contentHeight}px > container ${resp.containerHeight}px (+${resp.overflowBy}px)`,
-		);
+	if (hasOverflow) {
+		const details: string[] = [];
+		if ((resp.overflowBy ?? 0) > 0) {
+			details.push(
+				`  Vertical: content ${resp.contentHeight}px > container ${resp.containerHeight}px (+${resp.overflowBy}px)`,
+			);
+		}
+		if ((resp.overflowByW ?? 0) > 0) {
+			details.push(
+				`  Horizontal: content ${resp.contentWidth}px > container ${resp.containerWidth}px (+${resp.overflowByW}px)`,
+			);
+		}
+		if (overflowing.length > 0) {
+			details.push(`  Overflowing: ${overflowing.join(", ")}`);
+		}
+		if (details.length === 0) {
+			details.push(
+				"  Elements exceed page bounds (check absolute positioning or transforms)",
+			);
+		}
+		return {
+			status: "overflow",
+			text: `\n⛔ Layout overflow — not shippable:\n${details.join("\n")}`,
+			overflowIds: overflowing,
+		};
 	}
-	if ((resp.overflowByW ?? 0) > 0) {
-		details.push(
-			`  Horizontal: content ${resp.contentWidth}px > container ${resp.containerWidth}px (+${resp.overflowByW}px)`,
-		);
+	// No overflow — test the tight threshold on vertical clearance.
+	const containerH = resp.containerHeight ?? 0;
+	const contentH = resp.contentHeight ?? 0;
+	if (containerH > 0 && contentH > 0) {
+		const bottomMarginPx = containerH - contentH;
+		const thresholdMm = tightThresholdMm(canvas.h);
+		const thresholdPx = thresholdMm * PX_PER_MM;
+		if (bottomMarginPx < thresholdPx) {
+			const bottomMarginMm = Math.round(bottomMarginPx / PX_PER_MM);
+			return {
+				status: "tight",
+				text: `\n⚠ Layout tight — bottom margin ${bottomMarginMm}mm (min ${Math.round(thresholdMm)}mm). Tighten or move content up before shipping.`,
+				overflowIds: [],
+			};
+		}
 	}
-	if (overflowing.length > 0) {
-		details.push(`  Overflowing: ${overflowing.join(", ")}`);
-	}
-	if (details.length === 0) {
-		details.push(
-			"  Elements exceed page bounds (check absolute positioning or transforms)",
-		);
-	}
-	return `\nⓘ Layout overflow — non-blocking:\n${details.join("\n")}`;
+	return { status: "ok", text: "\n✓ Layout OK", overflowIds: [] };
 }
 
 // Run inside puppeteer — has access to `document`.

--- a/packages/server/src/services/layout.ts
+++ b/packages/server/src/services/layout.ts
@@ -189,6 +189,13 @@ export interface LayoutReport {
 	overflow?: boolean;
 	containerHeight?: number;
 	contentHeight?: number;
+	/**
+	 * Bottommost edge of any [data-id] descendant relative to the root's top,
+	 * in px. Used for the tight clearance check — `contentHeight` falls back
+	 * to `root.scrollHeight` which always equals `containerHeight` on a
+	 * fixed-size root, masking the real bottom margin.
+	 */
+	childMaxBottom?: number;
 	overflowBy?: number;
 	containerWidth?: number;
 	contentWidth?: number;
@@ -374,12 +381,12 @@ export function formatLayoutReport(
 		};
 	}
 	const containerH = resp.containerHeight ?? 0;
-	const contentH = resp.contentHeight ?? 0;
+	const childBottom = resp.childMaxBottom ?? 0;
 	const thresholdMm = tightThresholdMm(canvas.h);
-	const bottomMarginPx = containerH - contentH;
+	const bottomMarginPx = containerH - childBottom;
 	if (
 		containerH > 0 &&
-		contentH > 0 &&
+		childBottom > 0 &&
 		bottomMarginPx < thresholdMm * PX_PER_MM
 	) {
 		const bottomMarginMm = Math.round(bottomMarginPx / PX_PER_MM);
@@ -435,6 +442,9 @@ function measureInBrowser() {
 		: root.scrollWidth;
 	const contentHeight = Math.round(maxBottom - minTop);
 	const contentWidth = Math.round(maxRight - minLeft);
+	const childMaxBottom = elements.length
+		? Math.round(Math.max(0, ...elements.map((el) => el.bottom)))
+		: 0;
 	const overflowing = elements
 		.filter((el) => el.overflow)
 		.map((el) => el.id || el.name || "")
@@ -445,6 +455,7 @@ function measureInBrowser() {
 		overflow: overflowV || overflowH || overflowing.length > 0,
 		containerHeight,
 		contentHeight,
+		childMaxBottom,
 		overflowBy: overflowV ? contentHeight - containerHeight : 0,
 		containerWidth,
 		contentWidth,

--- a/packages/server/src/services/layout.ts
+++ b/packages/server/src/services/layout.ts
@@ -31,35 +31,23 @@ import type { Document } from "../types.js";
 import type { Documents } from "./documents.js";
 import type { WsRegistry } from "./ws-registry.js";
 
-/**
- * Structured layout verdict. Services return this instead of a raw string
- * so the tool layer can branch on `status` (e.g. emit `next:` hints on
- * tight/overflow) without parsing text back.
- *
- * - `text` is newline-prefixed for direct concatenation into set/patch
- *   responses. The check runner trims before rendering in isolation.
- * - `overflowIds` lists the `data-id` of elements flagged by the mm-math
- *   walker or headless measurement. Empty when status is `ok` or `tight`.
- */
+/** px per mm at 96 DPI — matches the viewport puppeteer renders into. */
+const PX_PER_MM = 96 / 25.4;
+
 export interface LayoutResult {
 	status: "ok" | "tight" | "overflow";
+	/** Newline-prefixed for direct concatenation; check runner trims. */
 	text: string;
 	overflowIds: string[];
 }
 
 export interface LayoutService {
-	/**
-	 * Broadcast the new page state so connected previews refresh, then return
-	 * a canvas-authoritative layout verdict.
-	 */
+	/** Broadcasts state for live preview, then measures. */
 	measure(
 		doc: Document,
 		pageHtml: string,
 		pageIdx: number,
 	): Promise<LayoutResult>;
-	/**
-	 * Return a layout verdict for `maket_html check` (no state broadcast).
-	 */
 	check(
 		doc: Document,
 		pageHtml: string,
@@ -143,11 +131,10 @@ body { margin: 0; padding: 0; width: ${w}mm; height: ${h}mm; overflow: hidden; b
 </head>
 <body>${html}</body>
 </html>`;
-			const scale = 96 / 25.4;
 			await installNetworkGuard(page, "localhost-only");
 			await page.setViewport({
-				width: Math.ceil(w * scale),
-				height: Math.ceil(h * scale),
+				width: Math.ceil(w * PX_PER_MM),
+				height: Math.ceil(h * PX_PER_MM),
 			});
 			await page.setContent(fullHtml, { waitUntil: "networkidle0" });
 			await page.evaluate(() => document.fonts.ready);
@@ -163,15 +150,11 @@ body { margin: 0; padding: 0; width: ${w}mm; height: ${h}mm; overflow: hidden; b
 		doc: Document,
 		pageHtml: string,
 	): Promise<LayoutResult> {
-		// serverLayoutCheck is fast and authoritative for declared-mm dimensions
-		// (width/height > canvas, flex-row children sum, absolute overshoot).
-		// If it flags overflow, report that — no need to warm puppeteer.
+		// Skip puppeteer when mm-math already sees overflow.
 		const serverResult = serverLayoutCheck(pageHtml, doc.canvas);
 		if (serverResult.status === "overflow") return serverResult;
-		// Otherwise fall through to headless rendering, which also catches
-		// content-driven overflow and the "tight" threshold (bottom margin
-		// below the min ship clearance). Missing puppeteer falls back to the
-		// server's OK.
+		// Headless catches content-driven overflow + the tight threshold;
+		// falls back to the server's ok when puppeteer is unavailable.
 		const headless = await headlessCheck(doc, pageHtml);
 		if (headless) return formatLayoutReport(headless, doc.canvas);
 		return serverResult;
@@ -189,9 +172,6 @@ body { margin: 0; padding: 0; width: ${w}mm; height: ${h}mm; overflow: hidden; b
 
 	return {
 		async measure(doc, pageHtml, pageIdx) {
-			// Push the new state to connected previews immediately — independent
-			// of the measurement. Agents previously relied on this to see their
-			// edits without reloading.
 			broadcastState(doc, pageIdx);
 			return runMeasure(doc, pageHtml);
 		},
@@ -332,13 +312,10 @@ export function serverLayoutCheck(
 	};
 }
 
-/** px per mm at 96 DPI — `installNetworkGuard` renders at this scale. */
-const PX_PER_MM = 96 / 25.4;
-
 /**
- * Minimum bottom-margin clearance before a page is considered "shippable".
- * Scales with canvas height so a 148mm A5 and a 297mm A4 both get a
- * reasonable guardrail (~10mm on A5, ~15mm on A4), without a config knob.
+ * Min bottom-margin clearance before a page counts as "shippable". Scales
+ * with canvas height so A5 and A4 both get a sensible guardrail without a
+ * config knob.
  */
 function tightThresholdMm(canvasH: number): number {
 	return Math.max(10, canvasH * 0.05);
@@ -351,34 +328,33 @@ export function formatLayoutReport(
 	if (!resp) {
 		return {
 			status: "overflow",
-			text: "\n⚠ Layout check unavailable",
+			text: "\n⛔ Layout check unavailable",
 			overflowIds: [],
 		};
 	}
-	const overflowing = [
-		...new Set(
-			[
-				...(resp.overflowing || []),
-				...(resp.elements || [])
-					.filter((el) => el.overflow)
-					.map((el) => el.id || el.name || ""),
-			].filter(Boolean),
-		),
-	];
-	const hasOverflow = Boolean(
-		resp.overflow ||
-			(resp.overflowBy ?? 0) > 0 ||
-			(resp.overflowByW ?? 0) > 0 ||
-			overflowing.length,
-	);
-	if (hasOverflow) {
+	const vOverflow = (resp.overflowBy ?? 0) > 0;
+	const hOverflow = (resp.overflowByW ?? 0) > 0;
+	const hasElementOverflow =
+		(resp.overflowing?.length ?? 0) > 0 ||
+		(resp.elements?.some((el) => el.overflow) ?? false);
+	if (resp.overflow || vOverflow || hOverflow || hasElementOverflow) {
+		const overflowing = [
+			...new Set(
+				[
+					...(resp.overflowing || []),
+					...(resp.elements || [])
+						.filter((el) => el.overflow)
+						.map((el) => el.id || el.name || ""),
+				].filter(Boolean),
+			),
+		];
 		const details: string[] = [];
-		if ((resp.overflowBy ?? 0) > 0) {
+		if (vOverflow) {
 			details.push(
 				`  Vertical: content ${resp.contentHeight}px > container ${resp.containerHeight}px (+${resp.overflowBy}px)`,
 			);
 		}
-		if ((resp.overflowByW ?? 0) > 0) {
+		if (hOverflow) {
 			details.push(
 				`  Horizontal: content ${resp.contentWidth}px > container ${resp.containerWidth}px (+${resp.overflowByW}px)`,
 			);
@@ -397,21 +373,21 @@ export function formatLayoutReport(
 			overflowIds: overflowing,
 		};
 	}
-	// No overflow — test the tight threshold on vertical clearance.
 	const containerH = resp.containerHeight ?? 0;
 	const contentH = resp.contentHeight ?? 0;
-	if (containerH > 0 && contentH > 0) {
-		const bottomMarginPx = containerH - contentH;
-		const thresholdMm = tightThresholdMm(canvas.h);
-		const thresholdPx = thresholdMm * PX_PER_MM;
-		if (bottomMarginPx < thresholdPx) {
-			const bottomMarginMm = Math.round(bottomMarginPx / PX_PER_MM);
-			return {
-				status: "tight",
-				text: `\n⚠ Layout tight — bottom margin ${bottomMarginMm}mm (min ${Math.round(thresholdMm)}mm). Tighten or move content up before shipping.`,
-				overflowIds: [],
-			};
-		}
+	const thresholdMm = tightThresholdMm(canvas.h);
+	const bottomMarginPx = containerH - contentH;
+	if (
+		containerH > 0 &&
+		contentH > 0 &&
+		bottomMarginPx < thresholdMm * PX_PER_MM
+	) {
+		const bottomMarginMm = Math.round(bottomMarginPx / PX_PER_MM);
+		return {
+			status: "tight",
+			text: `\n⚠ Layout tight — bottom margin ${bottomMarginMm}mm (min ${Math.round(thresholdMm)}mm). Tighten or move content up before shipping.`,
+			overflowIds: [],
+		};
 	}
 	return { status: "ok", text: "\n✓ Layout OK", overflowIds: [] };
 }

--- a/packages/server/src/services/pdf.ts
+++ b/packages/server/src/services/pdf.ts
@@ -19,6 +19,7 @@ import { parseCharteVars } from "../lib/charte-css.js";
 import { escapeCssValue, stripStyleClose } from "../lib/css-escape.js";
 import { inlineImages } from "../lib/image-inline.js";
 import { installNetworkGuard } from "../lib/page-network-guard.js";
+import { waitForPageStable } from "../lib/page-stable-wait.js";
 import type { Document } from "../types.js";
 import type { AssetsService } from "./assets.js";
 import type { BrowserPool } from "./browser-pool.js";
@@ -103,7 +104,7 @@ export function createPdfService(
 			try {
 				await installNetworkGuard(p, "offline");
 				await p.setContent(fullHtml, { waitUntil: "networkidle0" });
-				await p.evaluate(() => document.fonts.ready);
+				await waitForPageStable(p);
 				const pdfBuffer = await p.pdf({
 					width: `${w}mm`,
 					height: `${h}mm`,

--- a/packages/server/src/services/thumbnail.ts
+++ b/packages/server/src/services/thumbnail.ts
@@ -16,6 +16,7 @@
 import { escapeCssValue, stripStyleClose } from "../lib/css-escape.js";
 import { inlineImages } from "../lib/image-inline.js";
 import { installNetworkGuard } from "../lib/page-network-guard.js";
+import { waitForPageStable } from "../lib/page-stable-wait.js";
 import type { Document } from "../types.js";
 import type { AssetsService } from "./assets.js";
 import type { BrowserPool } from "./browser-pool.js";
@@ -81,7 +82,7 @@ async function defaultSnapshot(
 		await installNetworkGuard(page, "offline");
 		await page.setViewport(viewport);
 		await page.setContent(html, { waitUntil: "networkidle0" });
-		await page.evaluate(() => document.fonts.ready);
+		await waitForPageStable(page);
 		const png = await page.screenshot({
 			type: "png",
 			clip: { x: 0, y: 0, width: viewport.width, height: viewport.height },

--- a/packages/server/src/tools/canvas.ts
+++ b/packages/server/src/tools/canvas.ts
@@ -36,6 +36,13 @@ const FormatSchema = z.enum([
 	"MOBILE",
 ]);
 
+const MarginsSchema = z.object({
+	top: z.number(),
+	right: z.number(),
+	bottom: z.number(),
+	left: z.number(),
+});
+
 const MaketCanvasSchema = z.object({
 	doc: z.string().describe("Document name."),
 	format: FormatSchema.optional().describe(
@@ -51,10 +58,9 @@ const MaketCanvasSchema = z.object({
 		.describe(
 			"CSS background colour. Unspecified keeps the current value. Prefer var(--charte-color-bg) when a charte is loaded.",
 		),
-	textMargin: z
-		.number()
-		.optional()
-		.describe("Textual margin in mm. Unspecified keeps the current value."),
+	margins: MarginsSchema.optional().describe(
+		"Per-side safe-zone insets in mm: {top, right, bottom, left}. The layout verdict reports `tight` when blocks cross into any band, and the client draws dashed guides at these insets. Unspecified keeps the current value.",
+	),
 });
 
 const DESCRIPTION = [
@@ -89,14 +95,15 @@ export function createMaketCanvasTool(deps: CanvasDeps): ToolHandler {
 				w,
 				h,
 				bg: args.background || d.canvas.bg,
-				textMargin: args.textMargin ?? d.canvas.textMargin,
+				margins: args.margins ?? d.canvas.margins,
 			};
 			bus.emit("canvas:changed", { docName: d.name });
-			const tm = d.canvas.textMargin
-				? `  textMargin:${d.canvas.textMargin}mm`
+			const m = d.canvas.margins;
+			const mDesc = m
+				? `  margins:{t:${m.top} r:${m.right} b:${m.bottom} l:${m.left}}mm`
 				: "";
 			return text(
-				`Canvas: ${fmt} ${orient} (${w}x${h}mm) bg=${d.canvas.bg}${tm}`,
+				`Canvas: ${fmt} ${orient} (${w}x${h}mm) bg=${d.canvas.bg}${mDesc}`,
 			);
 		},
 	};

--- a/packages/server/src/tools/documents.ts
+++ b/packages/server/src/tools/documents.ts
@@ -109,10 +109,17 @@ const MaketDocSchema = z.object({
 		.describe(
 			"For new/meta: name of an existing charte to associate with this document. The charte itself is applied later via maket_charte view.",
 		),
-	textMargin: z
-		.number()
+	margins: z
+		.object({
+			top: z.number(),
+			right: z.number(),
+			bottom: z.number(),
+			left: z.number(),
+		})
 		.optional()
-		.describe("For new: textual margin in mm. Optional."),
+		.describe(
+			"For new: per-side safe-zone insets in mm {top, right, bottom, left}. Optional.",
+		),
 	designNotes: z
 		.string()
 		.optional()
@@ -219,7 +226,7 @@ function runNew(args: Args, documents: Documents, bus: Bus) {
 			w,
 			h,
 			bg: args.background || "#ffffff",
-			textMargin: args.textMargin,
+			margins: args.margins,
 		},
 		meta: { charte: args.charte },
 	});

--- a/packages/server/src/tools/html.test.ts
+++ b/packages/server/src/tools/html.test.ts
@@ -4,24 +4,36 @@ import { join } from "node:path";
 import { describe, expect, it, vi } from "vitest";
 import { createAssetsService } from "../services/assets.js";
 import { createDocuments } from "../services/documents.js";
-import type { LayoutService } from "../services/layout.js";
+import type { LayoutResult, LayoutService } from "../services/layout.js";
 import { createSQLiteStore } from "../services/store.js";
 import { createDocument } from "../types.js";
 import { createMaketHtmlTool, htmlPack } from "./html.js";
 
-function fakeLayout(): LayoutService & { measure: ReturnType<typeof vi.fn> } {
+const OK_RESULT: LayoutResult = {
+	status: "ok",
+	text: "\n✓ Layout OK",
+	overflowIds: [],
+};
+
+function fakeLayout(result: LayoutResult = OK_RESULT): LayoutService & {
+	measure: ReturnType<typeof vi.fn>;
+	check: ReturnType<typeof vi.fn>;
+} {
 	return {
-		measure: vi.fn(async () => "\n✓ Layout OK"),
-		check: vi.fn(async () => "✓ Layout OK"),
-	} as LayoutService & { measure: ReturnType<typeof vi.fn> };
+		measure: vi.fn(async () => result),
+		check: vi.fn(async () => result),
+	} as unknown as LayoutService & {
+		measure: ReturnType<typeof vi.fn>;
+		check: ReturnType<typeof vi.fn>;
+	};
 }
 
-function fixture() {
+function fixture(layoutResult: LayoutResult = OK_RESULT) {
 	const tmp = mkdtempSync(join(tmpdir(), "maket-html-"));
 	const store = createSQLiteStore(":memory:");
 	const documents = createDocuments({ store });
 	const assets = createAssetsService({ assetsDir: tmp });
-	const layout = fakeLayout();
+	const layout = fakeLayout(layoutResult);
 	return {
 		store,
 		documents,
@@ -422,6 +434,110 @@ describe("maket_html — action=check", () => {
 			NO_EXTRA,
 		);
 		expect(res.isError).toBe(true);
+		store.close();
+	});
+});
+
+describe("maket_html — layout signal → next: hints", () => {
+	const TIGHT: LayoutResult = {
+		status: "tight",
+		text: "\n⚠ Layout tight — bottom margin 4mm (min 15mm). Tighten or move content up before shipping.",
+		overflowIds: [],
+	};
+	const OVERFLOW: LayoutResult = {
+		status: "overflow",
+		text: "\n⛔ Layout overflow — not shippable:\n  Vertical: content 400px > container 358px (+42px)\n  Overflowing: footer, p3-footer-left",
+		overflowIds: ["footer", "p3-footer-left"],
+	};
+
+	it("keeps the response clean when layout is ok (no next: block)", async () => {
+		const { store, documents, layout, assets } = fixture(OK_RESULT);
+		store.saveDoc(makeDoc("d", `<div data-id="x">x</div>`));
+		documents.loadAll();
+		const tool = createMaketHtmlTool({ documents, store, layout, assets });
+		const res = await tool.handler(
+			{ action: "check", doc: "d", page: 1 },
+			NO_EXTRA,
+		);
+		expect((res.content[0] as any).text).not.toMatch(/^next:/m);
+		store.close();
+	});
+
+	it("appends snapshot + patch hints on tight (no specific ids)", async () => {
+		const { store, documents, layout, assets } = fixture(TIGHT);
+		store.saveDoc(makeDoc("d", `<div data-id="x">x</div>`));
+		documents.loadAll();
+		const tool = createMaketHtmlTool({ documents, store, layout, assets });
+		const res = await tool.handler(
+			{ action: "check", doc: "d", page: 1 },
+			NO_EXTRA,
+		);
+		const body = (res.content[0] as any).text as string;
+		expect(body).toMatch(/Layout tight/);
+		expect(body).toMatch(/next:/);
+		expect(body).toMatch(/maket_preview action=snapshot doc=d page=1/);
+		expect(body).toMatch(/maket_html action=patch doc=d page=1/);
+		expect(body).toMatch(/reduce paddings\/margins/);
+		store.close();
+	});
+
+	it("targets overflowing ids in the patch hint on overflow", async () => {
+		const { store, documents, layout, assets } = fixture(OVERFLOW);
+		store.saveDoc(makeDoc("d", `<div data-id="x">x</div>`));
+		documents.loadAll();
+		const tool = createMaketHtmlTool({ documents, store, layout, assets });
+		const res = await tool.handler(
+			{ action: "check", doc: "d", page: 1 },
+			NO_EXTRA,
+		);
+		const body = (res.content[0] as any).text as string;
+		expect(body).toMatch(/next:/);
+		expect(body).toMatch(/maket_preview action=snapshot doc=d page=1/);
+		expect(body).toMatch(
+			/maket_html action=patch doc=d page=1.*# target: footer, p3-footer-left/,
+		);
+		store.close();
+	});
+
+	it("wires hints through action=set so agents see them after writing", async () => {
+		const { store, documents, layout, assets } = fixture(OVERFLOW);
+		store.saveDoc(makeDoc("d"));
+		documents.loadAll();
+		const tool = createMaketHtmlTool({ documents, store, layout, assets });
+		const res = await tool.handler(
+			{
+				action: "set",
+				doc: "d",
+				page: 1,
+				html: `<div data-id="a">x</div>`,
+			},
+			NO_EXTRA,
+		);
+		const body = (res.content[0] as any).text as string;
+		expect(body).toMatch(/Layout overflow/);
+		expect(body).toMatch(/next:/);
+		expect(body).toMatch(/maket_preview action=snapshot doc=d page=1/);
+		store.close();
+	});
+
+	it("wires hints through action=patch so agents see them after edits", async () => {
+		const { store, documents, layout, assets } = fixture(TIGHT);
+		store.saveDoc(makeDoc("d", `<div data-id="a">x</div>`));
+		documents.loadAll();
+		const tool = createMaketHtmlTool({ documents, store, layout, assets });
+		const res = await tool.handler(
+			{
+				action: "patch",
+				doc: "d",
+				page: 1,
+				ops: [{ id: "a", style: { color: "red" } }],
+			},
+			NO_EXTRA,
+		);
+		const body = (res.content[0] as any).text as string;
+		expect(body).toMatch(/Layout tight/);
+		expect(body).toMatch(/next:/);
+		expect(body).toMatch(/maket_preview action=snapshot doc=d page=1/);
 		store.close();
 	});
 });

--- a/packages/server/src/tools/html.test.ts
+++ b/packages/server/src/tools/html.test.ts
@@ -13,6 +13,7 @@ const OK_RESULT: LayoutResult = {
 	status: "ok",
 	text: "\n✓ Layout OK",
 	overflowIds: [],
+	overlapIds: [],
 };
 
 function fakeLayout(result: LayoutResult = OK_RESULT): LayoutService & {
@@ -443,11 +444,13 @@ describe("maket_html — layout signal → next: hints", () => {
 		status: "tight",
 		text: "\n⚠ Layout tight — bottom margin 4mm (min 15mm). Tighten or move content up before shipping.",
 		overflowIds: [],
+		overlapIds: [],
 	};
 	const OVERFLOW: LayoutResult = {
 		status: "overflow",
 		text: "\n⛔ Layout overflow — not shippable:\n  Vertical: content 400px > container 358px (+42px)\n  Overflowing: footer, p3-footer-left",
 		overflowIds: ["footer", "p3-footer-left"],
+		overlapIds: [],
 	};
 
 	it("keeps the response clean when layout is ok (no next: block)", async () => {

--- a/packages/server/src/tools/html.ts
+++ b/packages/server/src/tools/html.ts
@@ -125,28 +125,20 @@ function resolveDocPage(
 	return { doc, page, pageIdx };
 }
 
-/**
- * Action hints shown in the `next:` block when layout isn't OK. Keeps `ok`
- * responses clean (no trailing block), and on tight/overflow pushes the
- * agent toward the two things that actually help: a visual snapshot and a
- * targeted patch. We drop ids into a shell-style comment so the hint stays
- * a valid-looking command.
- */
 function layoutNextHints(
 	result: LayoutResult,
 	docName: string,
 	page: number,
 ): string[] | undefined {
 	if (result.status === "ok") return undefined;
-	const hints = [`maket_preview action=snapshot doc=${docName} page=${page}`];
 	const target =
 		result.overflowIds.length > 0
 			? `  # target: ${result.overflowIds.join(", ")}`
 			: "  # reduce paddings/margins to add bottom clearance";
-	hints.push(
+	return [
+		`maket_preview action=snapshot doc=${docName} page=${page}`,
 		`maket_html action=patch doc=${docName} page=${page} ops=[...]${target}`,
-	);
-	return hints;
+	];
 }
 
 // ============================================================
@@ -376,7 +368,7 @@ export function createMaketHtmlTool(deps: HtmlDeps): ToolHandler {
 				case "get":
 					return runGet(args, page);
 				case "check":
-					return runCheck(doc, page, pageIdx, args.page, layout);
+					return runCheck(doc, page, pageIdx, layout);
 			}
 		},
 	};
@@ -499,13 +491,12 @@ async function runCheck(
 	doc: Document,
 	page: Page,
 	pageIdx: number,
-	page1based: number,
 	layout: LayoutService,
 ): Promise<ToolResult> {
 	if (!page.html) return text("No HTML content on this page", true);
 	const layoutResult = await layout.check(doc, page.html, pageIdx);
 	return text(layoutResult.text.trim(), {
-		next: layoutNextHints(layoutResult, doc.name, page1based),
+		next: layoutNextHints(layoutResult, doc.name, pageIdx + 1),
 	});
 }
 

--- a/packages/server/src/tools/html.ts
+++ b/packages/server/src/tools/html.ts
@@ -131,10 +131,17 @@ function layoutNextHints(
 	page: number,
 ): string[] | undefined {
 	if (result.status === "ok") return undefined;
+	const targets = [
+		...new Set([
+			...result.overflowIds,
+			...result.overlapIds,
+			...(result.tightIds ?? []),
+		]),
+	].filter(Boolean);
 	const target =
-		result.overflowIds.length > 0
-			? `  # target: ${result.overflowIds.join(", ")}`
-			: "  # reduce paddings/margins to add bottom clearance";
+		targets.length > 0
+			? `  # target: ${targets.join(", ")}`
+			: "  # reduce paddings/margins to add clearance inside the safe zone";
 	return [
 		`maket_preview action=snapshot doc=${docName} page=${page}`,
 		`maket_html action=patch doc=${docName} page=${page} ops=[...]${target}`,

--- a/packages/server/src/tools/html.ts
+++ b/packages/server/src/tools/html.ts
@@ -22,7 +22,7 @@ import { stripActiveHtml } from "../lib/strip-active-html.js";
 import type { AssetsService } from "../services/assets.js";
 import { validateCharteToken } from "../services/assets.js";
 import type { Documents } from "../services/documents.js";
-import type { LayoutService } from "../services/layout.js";
+import type { LayoutResult, LayoutService } from "../services/layout.js";
 import type { Store } from "../services/store.js";
 import type { Charte, Document, Page } from "../types.js";
 import { lockGuard, text } from "./_helpers.js";
@@ -123,6 +123,30 @@ function resolveDocPage(
 	const page = doc.pages[pageIdx];
 	if (!page) return `Page ${page1based} not found (${doc.pages.length} pages)`;
 	return { doc, page, pageIdx };
+}
+
+/**
+ * Action hints shown in the `next:` block when layout isn't OK. Keeps `ok`
+ * responses clean (no trailing block), and on tight/overflow pushes the
+ * agent toward the two things that actually help: a visual snapshot and a
+ * targeted patch. We drop ids into a shell-style comment so the hint stays
+ * a valid-looking command.
+ */
+function layoutNextHints(
+	result: LayoutResult,
+	docName: string,
+	page: number,
+): string[] | undefined {
+	if (result.status === "ok") return undefined;
+	const hints = [`maket_preview action=snapshot doc=${docName} page=${page}`];
+	const target =
+		result.overflowIds.length > 0
+			? `  # target: ${result.overflowIds.join(", ")}`
+			: "  # reduce paddings/margins to add bottom clearance";
+	hints.push(
+		`maket_html action=patch doc=${docName} page=${page} ops=[...]${target}`,
+	);
+	return hints;
 }
 
 // ============================================================
@@ -312,7 +336,7 @@ const DESCRIPTION = [
 	"  set   — REPLACE the full page HTML. Rejects the whole payload on any violation. Requires context_token when the doc has a charte.",
 	"  patch — apply ops by data-id: style/content/attr/insert/replace/remove/clone/moveTo. Violating ops roll back individually, the rest still apply.",
 	"  get   — return current HTML; pass id=<data-id> for a single element, format=text to strip tags.",
-	"  check — measure layout overflow against the canvas size; no side effects. Overflow is reported as a non-blocking hint, not an error.",
+	"  check — measure layout against the canvas size; no side effects. Three states: ✓ OK, ⚠ tight (<min bottom margin — tighten before shipping), ⛔ overflow (not shippable). On tight/overflow, the `next:` block points to a snapshot + targeted patch.",
 ].join("\n");
 
 export function createMaketHtmlTool(deps: HtmlDeps): ToolHandler {
@@ -352,7 +376,7 @@ export function createMaketHtmlTool(deps: HtmlDeps): ToolHandler {
 				case "get":
 					return runGet(args, page);
 				case "check":
-					return runCheck(doc, page, pageIdx, layout);
+					return runCheck(doc, page, pageIdx, args.page, layout);
 			}
 		},
 	};
@@ -393,7 +417,7 @@ async function runSet(
 
 	const count = (page.html.match(/data-id=/g) || []).length;
 	const html = page.html || "";
-	const layoutInfo = await layout.measure(doc, html, pageIdx);
+	const layoutResult = await layout.measure(doc, html, pageIdx);
 	const tree = buildIdTree(html);
 
 	return text(
@@ -401,13 +425,14 @@ async function runSet(
 			`Page "${page.name || args.page}" updated — ${count} elements`,
 			"",
 			"layout:",
-			layoutInfo.trim(),
+			layoutResult.text.trim(),
 			"",
 			"tree:",
 			tree,
 			"",
 			"Tip: use maket_html patch to refine by data-id (style, content, insert, replace, remove).",
 		].join("\n"),
+		{ next: layoutNextHints(layoutResult, doc.name, args.page) },
 	);
 }
 
@@ -432,7 +457,7 @@ async function runPatch(
 	page.html = stripActiveHtml(normalizeImageSrc(root.innerHTML));
 	documents.persist(doc.name);
 
-	const layoutInfo = await layout.measure(doc, page.html || "", pageIdx);
+	const layoutResult = await layout.measure(doc, page.html || "", pageIdx);
 	const tree = buildIdTree(root);
 	return text(
 		[
@@ -440,11 +465,12 @@ async function runPatch(
 			results.join("\n"),
 			"",
 			"layout:",
-			layoutInfo.trim(),
+			layoutResult.text.trim(),
 			"",
 			"tree:",
 			tree,
 		].join("\n"),
+		{ next: layoutNextHints(layoutResult, doc.name, args.page) },
 	);
 }
 
@@ -473,10 +499,14 @@ async function runCheck(
 	doc: Document,
 	page: Page,
 	pageIdx: number,
+	page1based: number,
 	layout: LayoutService,
 ): Promise<ToolResult> {
 	if (!page.html) return text("No HTML content on this page", true);
-	return text(await layout.check(doc, page.html, pageIdx));
+	const layoutResult = await layout.check(doc, page.html, pageIdx);
+	return text(layoutResult.text.trim(), {
+		next: layoutNextHints(layoutResult, doc.name, page1based),
+	});
 }
 
 export const htmlPack: ToolPack = {

--- a/packages/server/src/tools/html.ts
+++ b/packages/server/src/tools/html.ts
@@ -335,7 +335,7 @@ const DESCRIPTION = [
 	"  set   — REPLACE the full page HTML. Rejects the whole payload on any violation. Requires context_token when the doc has a charte.",
 	"  patch — apply ops by data-id: style/content/attr/insert/replace/remove/clone/moveTo. Violating ops roll back individually, the rest still apply.",
 	"  get   — return current HTML; pass id=<data-id> for a single element, format=text to strip tags.",
-	"  check — measure layout against the canvas size; no side effects. Three states: ✓ OK, ⚠ tight (<min bottom margin — tighten before shipping), ⛔ overflow (not shippable). On tight/overflow, the `next:` block points to a snapshot + targeted patch.",
+	"  check — measure layout against the canvas + declared `canvas.margins`; no side effects. Status: ✓ OK, ⚠ tight (block crosses a declared margin band — tighten or move into the safe zone before shipping), ⛔ overflow (block escapes the canvas, not shippable; pairwise overlaps between `[data-id]` blocks are reported under this same status). On tight/overflow, the `next:` block points to a snapshot + targeted patch.",
 ].join("\n");
 
 export function createMaketHtmlTool(deps: HtmlDeps): ToolHandler {

--- a/packages/server/src/tools/preview.ts
+++ b/packages/server/src/tools/preview.ts
@@ -18,6 +18,7 @@ import { shouldDisableSandbox } from "../lib/chromium-sandbox.js";
 import { escapeCssValue, stripStyleClose } from "../lib/css-escape.js";
 import { inlineImages } from "../lib/image-inline.js";
 import { installNetworkGuard } from "../lib/page-network-guard.js";
+import { waitForPageStable } from "../lib/page-stable-wait.js";
 import { resolveSafeOutputPath } from "../lib/safe-output-path.js";
 import type { AssetsService } from "../services/assets.js";
 import type { Config } from "../services/config.js";
@@ -149,7 +150,7 @@ async function runSnapshot(
 			height: Math.ceil(h * scale),
 		});
 		await p.setContent(fullHtml, { waitUntil: "networkidle0" });
-		await p.evaluate(() => document.fonts.ready);
+		await waitForPageStable(p);
 		const png = (await p.screenshot({
 			type: "png",
 			fullPage: false,

--- a/packages/server/src/types.ts
+++ b/packages/server/src/types.ts
@@ -8,13 +8,46 @@ import crypto from "node:crypto";
 
 export { computeCanvasDims, FORMATS, SCREEN_FORMATS } from "@maket/shared";
 
+export interface Margins {
+	top: number;
+	right: number;
+	bottom: number;
+	left: number;
+}
+
 export interface Canvas {
 	format: string;
 	orientation: string;
 	w: number;
 	h: number;
 	bg: string;
-	textMargin?: number;
+	/**
+	 * Safe-zone insets in mm. When set, the layout verdict reports `tight`
+	 * for blocks that cross into any margin band, and the client draws
+	 * dashed guides at the inset edges. When absent, only overflow (canvas
+	 * edge crossings) is reported.
+	 */
+	margins?: Margins;
+}
+
+/**
+ * Canvas migration: pre-margins docs persisted a uniform `textMargin: number`.
+ * Mutates `canvas` in place to convert legacy `textMargin: N` to
+ * `margins: {top:N, right:N, bottom:N, left:N}` and drop the legacy field.
+ * No-op on canvases that already use the new shape or have no margins set.
+ */
+export function normalizeCanvas(canvas: Canvas): Canvas {
+	const legacy = (canvas as { textMargin?: number }).textMargin;
+	if (legacy != null && !canvas.margins) {
+		canvas.margins = {
+			top: legacy,
+			right: legacy,
+			bottom: legacy,
+			left: legacy,
+		};
+	}
+	delete (canvas as { textMargin?: number }).textMargin;
+	return canvas;
 }
 
 export interface DocMeta {

--- a/plugin/claude/skills/maket-review/SKILL.md
+++ b/plugin/claude/skills/maket-review/SKILL.md
@@ -24,7 +24,7 @@ All tools require explicit `doc` and `page` params — no implicit state.
 maket_workspace state(doc)     → doc info, format, charte, pages
 maket_html get(doc, page)      → page HTML source
 maket_charte view              → if a charte is set, read it to know the expected tokens
-maket_html check(doc, page)    → layout verdict: overflow | overlap | tight
+maket_html check(doc, page)    → status: ok | tight | overflow (overlap reported under overflow)
 maket_preview snapshot(doc, page) → visual screenshot for your own inspection
 ```
 
@@ -42,7 +42,7 @@ Check the HTML against this checklist. Each check has a severity:
 | **Broken images** | `src` pointing to non-existent files, wrong paths | Check `maket_image list`, fix `src` to use the correct filename |
 | **Overflow** | Block escapes the canvas | Reduce sizes or restructure layout |
 | **Overlap** | Two `[data-id]` blocks intersect | Move one block; intentional overlay → `position:absolute` on a wrapper, not on tagged blocks |
-| **Tight** | Block crosses a declared margin (warning, ship-risky in print) | Tighten paddings or fix margins via `maket_canvas margins={t,r,b,l}` |
+| **Tight** | Block crosses a declared margin (warning, ship-risky in print) | Tighten paddings or fix margins via `maket_canvas margins={top,right,bottom,left}` |
 
 #### Important (visual quality)
 
@@ -72,7 +72,7 @@ This is the layer that separates "it works" from "it's well placed". A document 
 **How to think about space:**
 
 Whitespace isn't "emptiness" — it's a design element. It guides the eye. A well-placed document has:
-1. **Margins that breathe** — declare the safe zone via `maket_canvas margins={t,r,b,l}`. More at the top than the bottom (the eye enters from the top)
+1. **Margins that breathe** — declare the safe zone via `maket_canvas margins={top,right,bottom,left}`. More at the top than the bottom (the eye enters from the top)
 2. **Regular vertical rhythm** — the same gap between sections, a smaller gap within a section
 3. **Consistent alignment** — if the title is centered, the subtitle is too. If the body is left-aligned, images align to the same edge
 4. **Balanced visual weight** — a large image at the top demands a counterweight at the bottom (logo, visible footer)

--- a/plugin/claude/skills/maket-review/SKILL.md
+++ b/plugin/claude/skills/maket-review/SKILL.md
@@ -24,7 +24,7 @@ All tools require explicit `doc` and `page` params — no implicit state.
 maket_workspace state(doc)     → doc info, format, charte, pages
 maket_html get(doc, page)      → page HTML source
 maket_charte view              → if a charte is set, read it to know the expected tokens
-maket_html check(doc, page)    → overflow and spacing report from the browser
+maket_html check(doc, page)    → layout verdict: overflow | overlap | tight
 maket_preview snapshot(doc, page) → visual screenshot for your own inspection
 ```
 
@@ -40,7 +40,9 @@ Check the HTML against this checklist. Each check has a severity:
 |-------|-----------------|-----|
 | **Missing data-id** | Elements without `data-id` — maket_html patch can't target them, messaging won't work | Add semantic `data-id` to each visible element |
 | **Broken images** | `src` pointing to non-existent files, wrong paths | Check `maket_image list`, fix `src` to use the correct filename |
-| **Overflow** | Content exceeds page dimensions (maket_html check reports overflow) | Reduce font sizes, adjust spacing, or restructure layout |
+| **Overflow** | Block escapes the canvas | Reduce sizes or restructure layout |
+| **Overlap** | Two `[data-id]` blocks intersect | Move one block; intentional overlay → `position:absolute` on a wrapper, not on tagged blocks |
+| **Tight** | Block crosses a declared margin (warning, ship-risky in print) | Tighten paddings or fix margins via `maket_canvas margins={t,r,b,l}` |
 
 #### Important (visual quality)
 
@@ -70,7 +72,7 @@ This is the layer that separates "it works" from "it's well placed". A document 
 **How to think about space:**
 
 Whitespace isn't "emptiness" — it's a design element. It guides the eye. A well-placed document has:
-1. **Margins that breathe** — 15mm minimum on the edges (print), more at the top than the bottom (the eye enters from the top)
+1. **Margins that breathe** — declare the safe zone via `maket_canvas margins={t,r,b,l}`. More at the top than the bottom (the eye enters from the top)
 2. **Regular vertical rhythm** — the same gap between sections, a smaller gap within a section
 3. **Consistent alignment** — if the title is centered, the subtitle is too. If the body is left-aligned, images align to the same edge
 4. **Balanced visual weight** — a large image at the top demands a counterweight at the bottom (logo, visible footer)

--- a/plugin/claude/skills/maket/SKILL.md
+++ b/plugin/claude/skills/maket/SKILL.md
@@ -178,7 +178,7 @@ See [references/layout-patterns.md](references/layout-patterns.md) for complete 
 
 ### Composition rules
 
-1. **Margins** — declare safe zone via `maket_canvas margins={t,r,b,l}`. Presets: `{10,10,10,10}` poster, `{15,15,15,18}` paperback (left binding), `{10,20,10,13}` magazine, `{25,25,25,25}` office doc. See `docs/layout.md`
+1. **Margins** — declare safe zone via `maket_canvas margins={top,right,bottom,left}`. Presets: `{top:10,right:10,bottom:10,left:10}` poster, `{top:15,right:15,bottom:15,left:18}` paperback (left binding), `{top:10,right:20,bottom:10,left:13}` magazine, `{top:25,right:25,bottom:25,left:25}` office doc. See `docs/layout.md`
 2. **Alignment** — Pick ONE anchor per section. Use `gap` for consistent spacing
 3. **Images in flex** — Always add `min-height:0` (column) or `min-width:0` (row) on `<img>` elements, otherwise they refuse to shrink
 4. **Z-order** — First in HTML = behind. Background first, text last. Use `position:absolute` only for overlays, scrims, and decorative elements

--- a/plugin/claude/skills/maket/SKILL.md
+++ b/plugin/claude/skills/maket/SKILL.md
@@ -178,7 +178,7 @@ See [references/layout-patterns.md](references/layout-patterns.md) for complete 
 
 ### Composition rules
 
-1. **Margins** — 10mm minimum from canvas edges (print), 8mm (screen)
+1. **Margins** — declare safe zone via `maket_canvas margins={t,r,b,l}`. Presets: `{10,10,10,10}` poster, `{15,15,15,18}` paperback (left binding), `{10,20,10,13}` magazine, `{25,25,25,25}` office doc. See `docs/layout.md`
 2. **Alignment** — Pick ONE anchor per section. Use `gap` for consistent spacing
 3. **Images in flex** — Always add `min-height:0` (column) or `min-width:0` (row) on `<img>` elements, otherwise they refuse to shrink
 4. **Z-order** — First in HTML = behind. Background first, text last. Use `position:absolute` only for overlays, scrims, and decorative elements


### PR DESCRIPTION
## Summary

Closes #14.

The original scope was a graduated `tight` state with an actionable `next:` hint. Smoke-testing on real docs surfaced two structural problems that pushed the scope wider: the threshold was a heuristic with no design justification (`max(10mm, h*0.05)`), and the verdict had no signal for blocks that overlap each other. This PR rebuilds the verdict on top of a real data-model change.

### Layout verdict — three orthogonal axes

| signal | fires when | severity |
|---|---|---|
| `overflow` | a `[data-id]` block crosses the canvas edge | non-shippable |
| `overlap` | two `[data-id]` blocks intersect (pairwise AABB, ancestor-skipped) | non-shippable |
| `tight` | a `[data-id]` block crosses a declared margin band | warning |

`ok` requires all three to be empty. `overflow` and `overlap` co-report when both fire.

### Data-model change — `Canvas.margins` per-side

`Canvas.textMargin?: number` (uniform) is replaced by `Canvas.margins?: { top, right, bottom, left }`. The hard-coded `tightThresholdMm = max(10, h*0.05)` heuristic is dropped — the verdict now reads margins straight from the canvas. No declared margins → no `tight` signal (only canvas-edge `overflow` reports).

Persisted docs migrate transparently via `normalizeCanvas(canvas)`: legacy `{textMargin: N}` becomes `{margins: {top:N, right:N, bottom:N, left:N}}` on load (`documents.loadAll` and `resolveOrLoad`). The legacy field is dropped in place.

`maket_canvas` and `maket_doc new` accept the new `margins` object on their tool surface; `textMargin` is removed from the public API.

### Headless measurement hardening

- **Wait procedure** completed: `fonts.ready` + `Promise.all(images.map(decode))` + `rAF×2`. Previously only `fonts.ready` — an unloaded `<img>` reported `naturalHeight=0` and the walker silently agreed the page fit. Extracted to `lib/page-stable-wait.ts` and reused by `pdf.ts`, `thumbnail.ts`, `tools/preview.ts` so all four puppeteer paths share the same stability contract. See puppeteer/puppeteer#422.
- **Root pick** uses the canonical `[data-id="page"]` selector (the format contract from `html.ts:296`), with `firstElementChild` as fallback for legacy content. Previously `firstElementChild` blindly — broke on user HTML starting with `<style>` or comments.
- **Tolerance** symmetric ±2px on overflow + tight detection (was `top<-1` / `bottom>h+1`, asymmetric).
- **Headless-unavailable** now surfaces explicitly in the verdict text (`✓ Layout OK (headless unavailable — content overflow + overlap unchecked)`) instead of silently falling back to the mm-math result, so the agent doesn't treat ✓ as full validation.

### Client visual guide

`PageCanvas` renders the cyan dashed margin guide from the new per-side `margins` field. The previous 0.5px / 0.3 alpha hairline was indistinguishable on white at default zoom — bumped to 1px / 0.7 alpha so the guide actually serves as a visual reference for the tight verdict.

### Smoke test (live, MCP-driven)

Validated on a single A4 doc with margins `{top:15, right:15, bottom:15, left:18}` (Book Printing UK paperback spec):

| case | setup | verdict | result |
|---|---|---|---|
| A — OK | minimal content well inside safe zone | \`✓ OK\` | ✓ |
| B — tight | footer at \`bottom:5mm\` (crosses 15mm band) | \`⚠ tight bottom: footer\` | ✓ |
| C — overflow | footer at \`top:280mm height:30mm\` (bottom=310 > 297) | \`⛔ overflow [footer] +13mm\` | ✓ |
| D — overlap | two \`position:absolute\` blocks that intersect | \`⛔ Overlapping a ↔ b\` | ✓ (caught a 3rd unintended pair too) |
| E — full doc | 14 tagged blocks, kicker / title / hero / 2 cols / footer | \`✓ OK\` | ✓ |
| F — shrink safe zone to 25/25/25/28 on E | | \`⚠ tight on 4 sides, 13 ids\` | ✓ |
| G — grow safe zone to 8/8/8/8 on E | | \`✓ OK\` | ✓ |

## Commits in this branch

1. \`dd6ce94\` — graduated tight state + actionable \`next:\` hints (original scope)
2. \`a41a1c9\` — /simplify pass (de-dup \`PX_PER_MM\`, flatten \`formatLayoutReport\`, drop narrator comments)
3. \`c263786\` — fix: tight uses \`childMaxBottom\`, not \`scrollHeight\` (was structurally degenerate on a fixed-height root)
4. \`71481be\` — per-side margins, pairwise overlap, shared page-stable wait (this round)

## Test plan

- [x] \`npm run quality\` — lint + typecheck + 591/591 vitest pass + version-alignment check
- [x] Live MCP smoke on A4 doc covering all four signals (A–D) plus full-page layout (E) and dynamic safe-zone resizing (F, G)
- [x] Tests cover: \`serverLayoutCheck\` overflow + id capture, \`formatLayoutReport\` per-side tight, overlap, co-reported overflow+overlap, headless-unavailable surfaced; \`LayoutService.measure\` for headless tight on bottom side
- [x] Verdict text format asserted (\`right: sidebar • bottom: footer\`)

## Breaking notes

- **Tool API**: \`maket_canvas\` and \`maket_doc new\` no longer accept \`textMargin\`. Use \`margins: {top, right, bottom, left}\` instead.
- **Doc storage**: legacy \`canvas.textMargin: N\` migrates automatically to symmetric per-side \`margins\` on load. The legacy field is dropped in place; on next save the doc is persisted with the new shape only.