### PR TITLE
refactor(wire-contracts): symmetric metadata writes + drop legacy sidecar

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -3,6 +3,13 @@
     "maket": {
       "type": "http",
       "url": "http://localhost:24843/mcp"
+    },
+    "esac": {
+      "type": "http",
+      "url": "http://localhost:3200/mcp",
+      "headers": {
+        "Authorization": "Bearer ${ESAC_TOKEN}"
+      }
     }
   }
 }

--- a/packages/client/src/store/ws.integration.test.ts
+++ b/packages/client/src/store/ws.integration.test.ts
@@ -324,7 +324,7 @@ describe("ack_messages", () => {
 	});
 });
 
-describe("remove_doc", () => {
+describe("doc_removed", () => {
 	it("removes the named doc from the workspace", async () => {
 		const { initWs, useStore } = await freshWsModule();
 		initWs();
@@ -334,7 +334,7 @@ describe("remove_doc", () => {
 			.getState()
 			.upsertDoc(doc("beta"), [summary("alpha"), summary("beta")], "");
 
-		MockWebSocket.last().emit({ type: "remove_doc", name: "beta" });
+		MockWebSocket.last().emit({ type: "doc_removed", name: "beta" });
 		expect(useStore.getState().workspaceDocNames).toEqual(["alpha"]);
 		expect(useStore.getState().docs.has("beta")).toBe(false);
 	});

--- a/packages/client/src/store/ws.ts
+++ b/packages/client/src/store/ws.ts
@@ -357,9 +357,21 @@ function connect(): void {
 			location.reload();
 		}
 
-		if (msg.type === "remove_doc") {
-			console.log("[ws] remove_doc:", msg.name);
+		if (msg.type === "doc_removed") {
+			console.log("[ws] doc_removed:", msg.name);
 			useStore.getState().removeDocFromWorkspace(msg.name);
+		}
+
+		if (msg.type === "charte_removed") {
+			const s = useStore.getState();
+			const chartesCss = new Map(s.chartesCss);
+			for (const [docName, doc] of s.docs) {
+				if (doc.meta?.charte === msg.name) chartesCss.set(docName, "");
+			}
+			useStore.setState({
+				chartesCss,
+				chartesVersion: s.chartesVersion + 1,
+			});
 		}
 
 		if (msg.type === "assets_changed") {

--- a/packages/server/index.ts
+++ b/packages/server/index.ts
@@ -216,6 +216,10 @@ bus.on("charte:updated", ({ name, css }) => {
 	wsRegistry.broadcast({ type: "charte_updated", name, css });
 });
 
+bus.on("charte:removed", ({ name }) => {
+	wsRegistry.broadcast({ type: "charte_removed", name });
+});
+
 bus.on("toast", ({ text, level, duration }) => {
 	wsRegistry.broadcast({
 		type: "toast",
@@ -226,7 +230,7 @@ bus.on("toast", ({ text, level, duration }) => {
 });
 
 bus.on("document:deleted", ({ docName }) => {
-	wsRegistry.broadcast({ type: "remove_doc", name: docName });
+	wsRegistry.broadcast({ type: "doc_removed", name: docName });
 });
 
 bus.on("messages:acked", ({ ids }) => {

--- a/packages/server/src/routes/assets.routes.test.ts
+++ b/packages/server/src/routes/assets.routes.test.ts
@@ -98,11 +98,7 @@ describe("assets routes", () => {
 		});
 	});
 
-	it("accepts JSON uploads, updates metadata.json, and emits assets:changed", async () => {
-		writeFileSync(
-			join(assetsDir, "metadata.json"),
-			JSON.stringify({ images: [] }),
-		);
+	it("accepts JSON uploads and emits assets:changed", async () => {
 		const changed = vi.fn();
 		bus.on("assets:changed", changed);
 
@@ -123,16 +119,6 @@ describe("assets routes", () => {
 		expect(readFileSync(join(assetsDir, "hello_world.png"), "utf-8")).toBe(
 			"pixel",
 		);
-		expect(
-			JSON.parse(readFileSync(join(assetsDir, "metadata.json"), "utf-8")),
-		).toEqual({
-			images: [
-				{
-					file: "hello_world.png",
-					title: "hello world",
-				},
-			],
-		});
 		expect(changed).toHaveBeenCalledWith({});
 		await new Promise((resolve) => setTimeout(resolve, 0));
 		expect(assets.optimize).toHaveBeenCalledWith("hello_world.png");

--- a/packages/server/src/routes/assets.routes.ts
+++ b/packages/server/src/routes/assets.routes.ts
@@ -4,6 +4,9 @@
  */
 
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+// SQLite `assets` table is the single source of truth for image metadata.
+// The legacy `${ASSETS_DIR}/metadata.json` sidecar was append-only and never
+// read at runtime — removed.
 import { extname, join, resolve, sep } from "node:path";
 import type { AssetsListResponse, UploadResponse } from "@maket/shared";
 import type { Response } from "express";
@@ -35,7 +38,7 @@ const ALLOWED_IMG_EXTS = new Set([
 	".gif",
 ]);
 
-const RESERVED_NAMES = new Set(["metadata.json", "thumbs"]);
+const RESERVED_NAMES = new Set(["thumbs"]);
 
 const VARIANTS: Record<
 	string,
@@ -202,19 +205,6 @@ export function createAssetsRouter({
 
 			const replaced = assets.exists(cleanName);
 			await assets.importBuffer(buf, cleanName, true);
-
-			// Add to metadata.json index if present (legacy).
-			const metaPath = join(ASSETS_DIR, "metadata.json");
-			if (existsSync(metaPath)) {
-				const meta = JSON.parse(readFileSync(metaPath, "utf-8"));
-				if (!meta.images.find((i: any) => i.file === cleanName)) {
-					meta.images.push({
-						file: cleanName,
-						title: cleanName.replace(/\.[^.]+$/, "").replace(/[-_]/g, " "),
-					});
-					writeFileSync(metaPath, JSON.stringify(meta, null, 2), "utf-8");
-				}
-			}
 
 			setTimeout(() => {
 				void assets.optimize(cleanName);

--- a/packages/server/src/services/assets.ts
+++ b/packages/server/src/services/assets.ts
@@ -101,9 +101,26 @@ export interface AssetsService {
 	 * returns the raw bytes inline to the model.
 	 */
 	validateImageFile(filename: string): { valid: boolean; reason?: string };
-	/** Compute a short HMAC token of filename + size + mtime. Null if file missing. */
+	/**
+	 * Proof-of-read token for an image. HMAC over filename + size + mtime,
+	 * signed with the per-process secret. Issued by `maket_image view` and
+	 * required by `maket_image meta` to prove the agent read the binary
+	 * before attributing metadata.
+	 *
+	 * Not optimistic concurrency control: the token doesn't protect against
+	 * concurrent writes. It only proves that *some* read happened in this
+	 * process's lifetime — the secret is regenerated on restart so tokens
+	 * issued by a previous process are unverifiable.
+	 *
+	 * Null if the file is missing.
+	 */
 	imageToken(filename: string): string | null;
-	/** Compute a short HMAC token of a charte's name + JSON hash. Null when no charte. */
+	/**
+	 * Proof-of-read token for a charte (HMAC over name + JSON hash). Same
+	 * semantics as `imageToken`: issued by `maket_charte view`, required by
+	 * `maket_html set/patch` to prove the brand guide was consulted before
+	 * the agent writes HTML against it. Not OCC. Null when no charte.
+	 */
 	charteToken(charte: { name: string } | null | undefined): string | null;
 	/** Read natural dimensions from PNG/JPEG header. Null if unknown/missing. */
 	getDimensions(filename: string): Dimensions | null;
@@ -490,7 +507,13 @@ export function createAssetsService(
 }
 
 /**
- * Token validators — decoupled from filesystem, pure logic.
+ * Proof-of-read token validators — decoupled from filesystem, pure logic.
+ *
+ * The contract these guards enforce: "the agent must have read the resource
+ * (asset / charte) in this server's lifetime before being allowed to write
+ * derived data". This is NOT optimistic concurrency control — there is no
+ * version vector, and a token re-issued after a no-op read passes the check.
+ * The guarantee is on read-before-write, not on intervening-write detection.
  */
 
 export function validateAssetToken(

--- a/packages/server/src/services/bus.ts
+++ b/packages/server/src/services/bus.ts
@@ -25,6 +25,7 @@ export interface BusEvents {
 	"assets:changed": Record<string, never>;
 	"meta:updated": { docName: string };
 	"charte:updated": { name: string; css: string };
+	"charte:removed": { name: string };
 	"messages:acked": { ids: string[] };
 	toast: { text: string; level?: string; duration?: number };
 }

--- a/packages/server/src/services/ws-handler.test.ts
+++ b/packages/server/src/services/ws-handler.test.ts
@@ -436,7 +436,7 @@ describe("ws-handler — file and document mutations", () => {
 
 		expect(documents.resolve("old")).toBeNull();
 		expect(documents.resolve("new")?.name).toBe("new");
-		expect(removed).toHaveBeenCalledWith({ type: "remove_doc", name: "old" });
+		expect(removed).toHaveBeenCalledWith({ type: "doc_removed", name: "old" });
 		expect(toast).toHaveBeenCalledWith(
 			expect.objectContaining({ text: expect.stringMatching(/old.*new/i) }),
 		);
@@ -617,6 +617,150 @@ describe("ws-handler — text editing", () => {
 
 		expect(store.loadAllChartes()).toHaveLength(0);
 		expect(updates).not.toHaveBeenCalled();
+		expect(toast).toHaveBeenCalledWith(
+			expect.objectContaining({ level: "error" }),
+		);
+		dispose();
+	});
+
+	it("update_charte_meta merges fields into an existing charte without wiping omitted ones", () => {
+		const { store, bus, handler, dispose } = fixture();
+		store.saveCharte({
+			name: "brand",
+			description: "v1 desc",
+			tokens: { color: { primary: "#2563EB" } },
+			voice: { personality: ["bold"] },
+		});
+		const updates = vi.fn();
+		bus.on("charte:updated", updates);
+
+		handler(
+			{
+				type: "update_charte_meta",
+				name: "brand",
+				description: "v2 desc",
+				rules: { titles: "sentence case" },
+			},
+			STUB_WS,
+		);
+
+		const stored = store.loadCharte("brand");
+		// Updated fields written.
+		expect(stored?.description).toBe("v2 desc");
+		expect(stored?.rules?.titles).toBe("sentence case");
+		// Omitted fields preserved.
+		expect(stored?.tokens.color?.primary).toBe("#2563EB");
+		expect(stored?.voice?.personality).toEqual(["bold"]);
+		// Wire emits the recomposed CSS so clients reload tokens/fonts.
+		expect(updates).toHaveBeenCalledWith(
+			expect.objectContaining({ name: "brand" }),
+		);
+		dispose();
+	});
+
+	it("update_charte_meta toasts when the charte does not exist (no creation)", () => {
+		const { store, bus, handler, dispose } = fixture();
+		const toast = vi.fn();
+		const updates = vi.fn();
+		bus.on("toast", toast);
+		bus.on("charte:updated", updates);
+
+		handler(
+			{
+				type: "update_charte_meta",
+				name: "nope",
+				description: "ghost",
+			},
+			STUB_WS,
+		);
+
+		expect(store.loadCharte("nope")).toBeNull();
+		expect(updates).not.toHaveBeenCalled();
+		expect(toast).toHaveBeenCalledWith(
+			expect.objectContaining({ level: "error" }),
+		);
+		dispose();
+	});
+
+	it("update_charte_meta rejects malformed tokens without persisting", () => {
+		const { store, bus, handler, dispose } = fixture();
+		store.saveCharte({
+			name: "brand",
+			tokens: { color: { primary: "#2563EB" } },
+		});
+		const updates = vi.fn();
+		const toast = vi.fn();
+		bus.on("charte:updated", updates);
+		bus.on("toast", toast);
+
+		handler(
+			{
+				type: "update_charte_meta",
+				name: "brand",
+				tokens: "oops" as unknown,
+			} as any,
+			STUB_WS,
+		);
+
+		// Existing charte left intact.
+		expect(store.loadCharte("brand")?.tokens.color?.primary).toBe("#2563EB");
+		expect(updates).not.toHaveBeenCalled();
+		expect(toast).toHaveBeenCalledWith(
+			expect.objectContaining({ level: "error" }),
+		);
+		dispose();
+	});
+
+	it("update_asset_meta merges fields into an existing asset row without wiping omitted ones", () => {
+		const { store, bus, assetsDir, handler, dispose } = fixture();
+		writeFileSync(join(assetsDir, "hero.png"), "px");
+		store.saveAsset({
+			filename: "hero.png",
+			title: "Old title",
+			description: "Old desc",
+			tags: ["a", "b"],
+		});
+		const changed = vi.fn();
+		bus.on("assets:changed", changed);
+
+		handler(
+			{
+				type: "update_asset_meta",
+				filename: "hero.png",
+				title: "New title",
+				credit: "@photographer",
+			},
+			STUB_WS,
+		);
+
+		const row = store.loadAsset("hero.png");
+		expect(row?.title).toBe("New title");
+		expect(row?.credit).toBe("@photographer");
+		// Omitted fields preserved by the COALESCE upsert.
+		expect(row?.description).toBe("Old desc");
+		expect(row?.tags).toEqual(["a", "b"]);
+		expect(changed).toHaveBeenCalledWith({});
+		dispose();
+	});
+
+	it("update_asset_meta toasts when the file is missing (no row creation)", () => {
+		const { store, bus, handler, dispose } = fixture();
+		const toast = vi.fn();
+		const changed = vi.fn();
+		bus.on("toast", toast);
+		bus.on("assets:changed", changed);
+
+		handler(
+			{
+				type: "update_asset_meta",
+				filename: "missing.png",
+				title: "Ghost",
+			},
+			STUB_WS,
+		);
+
+		expect(store.loadAsset("missing.png")).toBeNull();
+		expect(changed).not.toHaveBeenCalled();
 		expect(toast).toHaveBeenCalledWith(
 			expect.objectContaining({ level: "error" }),
 		);

--- a/packages/server/src/services/ws-handler.test.ts
+++ b/packages/server/src/services/ws-handler.test.ts
@@ -743,6 +743,38 @@ describe("ws-handler — text editing", () => {
 		dispose();
 	});
 
+	it.each([
+		["title as number", { title: 42 as unknown }],
+		["tags as string", { tags: "oops" as unknown }],
+		["tags non-string element", { tags: [1, 2] as unknown }],
+		["credit as object", { credit: { x: 1 } as unknown }],
+	])("update_asset_meta rejects malformed payload (%s) without persisting", (_, extra) => {
+		const { store, bus, assetsDir, handler, dispose } = fixture();
+		writeFileSync(join(assetsDir, "hero.png"), "px");
+		store.saveAsset({ filename: "hero.png", title: "kept" });
+		const toast = vi.fn();
+		const changed = vi.fn();
+		bus.on("toast", toast);
+		bus.on("assets:changed", changed);
+
+		handler(
+			{
+				type: "update_asset_meta",
+				filename: "hero.png",
+				...extra,
+			} as any,
+			STUB_WS,
+		);
+
+		// Existing row left intact.
+		expect(store.loadAsset("hero.png")?.title).toBe("kept");
+		expect(changed).not.toHaveBeenCalled();
+		expect(toast).toHaveBeenCalledWith(
+			expect.objectContaining({ level: "error" }),
+		);
+		dispose();
+	});
+
 	it("update_asset_meta toasts when the file is missing (no row creation)", () => {
 		const { store, bus, handler, dispose } = fixture();
 		const toast = vi.fn();

--- a/packages/server/src/services/ws-handler.ts
+++ b/packages/server/src/services/ws-handler.ts
@@ -267,6 +267,17 @@ export function createWsHandler(deps: WsHandlerDeps): WsMessageHandler {
 					});
 					break;
 				}
+				// Runtime shape check — without it a `tags: "oops"` (string)
+				// would persist as literal text and crash the next loadAsset on
+				// `JSON.parse(row.tags)`. Mirrors validateCharteSavePayload.
+				const invalid = validateAssetMetaPayload(msg);
+				if (invalid) {
+					bus.emit("toast", {
+						text: `Asset "${filename}" rejected: ${invalid}`,
+						level: "error",
+					});
+					break;
+				}
 				// store.saveAsset uses UPSERT with COALESCE on every field, so
 				// passing only the fields in msg preserves the others.
 				store.saveAsset({
@@ -505,5 +516,32 @@ function validateCharteSavePayload(msg: {
 			if (typeof val !== "string") return `rules.${k} must be a string`;
 		}
 	}
+	return null;
+}
+
+/** Runtime shape check for `update_asset_meta` payloads. Returns an error
+ * message when the payload would persist malformed data, `null` when it's
+ * safe. Same contract as validateCharteSavePayload. */
+function validateAssetMetaPayload(msg: {
+	title?: unknown;
+	description?: unknown;
+	category?: unknown;
+	tags?: unknown;
+	credit?: unknown;
+	orientation?: unknown;
+}): string | null {
+	for (const key of [
+		"title",
+		"description",
+		"category",
+		"credit",
+		"orientation",
+	] as const) {
+		const v = msg[key];
+		if (v !== undefined && typeof v !== "string")
+			return `${key} must be a string`;
+	}
+	if (msg.tags !== undefined && !isStringArray(msg.tags))
+		return "tags must be a string[]";
 	return null;
 }

--- a/packages/server/src/services/ws-handler.ts
+++ b/packages/server/src/services/ws-handler.ts
@@ -209,12 +209,75 @@ export function createWsHandler(deps: WsHandlerDeps): WsMessageHandler {
 				break;
 			}
 
+			case "update_charte_meta": {
+				const name = String(msg.name || "").trim();
+				if (!name) {
+					bus.emit("toast", {
+						text: "Charte name is required",
+						level: "error",
+					});
+					break;
+				}
+				const existing = store.loadCharte(name);
+				if (!existing) {
+					bus.emit("toast", {
+						text: `Charte "${name}" not found`,
+						level: "error",
+					});
+					break;
+				}
+				const invalid = validateCharteSavePayload(msg);
+				if (invalid) {
+					bus.emit("toast", {
+						text: `Charte "${name}" rejected: ${invalid}`,
+						level: "error",
+					});
+					break;
+				}
+				// Partial merge: only fields present in msg overwrite existing ones.
+				// Tokens replace the whole map when provided; omit to keep palette.
+				const merged: Charte = { ...existing };
+				if (msg.description !== undefined) merged.description = msg.description;
+				if (msg.tokens !== undefined)
+					merged.tokens = msg.tokens as Charte["tokens"];
+				if (msg.voice !== undefined) merged.voice = msg.voice;
+				if (msg.rules !== undefined) merged.rules = msg.rules;
+				store.saveCharte(merged);
+				bus.emit("charte:updated", { name, css: composeCharteCss(merged) });
+				break;
+			}
+
 			case "delete_asset": {
 				if (!msg.filename) break;
 				const filename = String(msg.filename);
 				if (!assets.exists(filename)) break;
 				assets.remove(filename);
 				store.deleteAsset(filename);
+				bus.emit("assets:changed", {});
+				break;
+			}
+
+			case "update_asset_meta": {
+				const filename = String(msg.filename || "");
+				if (!filename) break;
+				if (!assets.exists(filename)) {
+					bus.emit("toast", {
+						text: `Asset "${filename}" not found`,
+						level: "error",
+					});
+					break;
+				}
+				// store.saveAsset uses UPSERT with COALESCE on every field, so
+				// passing only the fields in msg preserves the others.
+				store.saveAsset({
+					filename,
+					title: msg.title,
+					description: msg.description,
+					category: msg.category,
+					tags: msg.tags,
+					credit: msg.credit,
+					orientation: msg.orientation,
+				});
 				bus.emit("assets:changed", {});
 				break;
 			}
@@ -283,13 +346,13 @@ export function createWsHandler(deps: WsHandlerDeps): WsMessageHandler {
 				}
 				// Rename path: the cache key moves, so we delete the old record from
 				// the store + cache, mutate d.name, and re-insert. A subsequent
-				// `document:loaded` broadcasts the new state; `remove_doc` for the
+				// `document:loaded` broadcasts the new state; `doc_removed` for the
 				// old name clears it from every connected client.
 				documents.delete(name);
 				d.name = newName;
 				documents.all().set(newName, d);
 				documents.persist(newName);
-				wsRegistry.broadcast({ type: "remove_doc", name });
+				wsRegistry.broadcast({ type: "doc_removed", name });
 				bus.emit("document:loaded", { docName: newName });
 				bus.emit("toast", {
 					text: `"${name}" → "${newName}"`,

--- a/packages/server/src/tools/chartes.test.ts
+++ b/packages/server/src/tools/chartes.test.ts
@@ -131,11 +131,11 @@ describe("maket_charte — action=set", () => {
 });
 
 describe("maket_charte — action=delete", () => {
-	it("deletes an existing charte and emits charte:updated (empty css)", async () => {
+	it("deletes an existing charte and emits charte:removed", async () => {
 		const { store, bus, assets, cleanup } = fixture();
 		store.saveCharte({ name: "gone", tokens: {} });
 		const listener = vi.fn();
-		bus.on("charte:updated", listener);
+		bus.on("charte:removed", listener);
 
 		const tool = createMaketCharteTool({ store, bus, assets });
 		const res = await tool.handler(
@@ -144,7 +144,7 @@ describe("maket_charte — action=delete", () => {
 		);
 		expect(res.isError).toBeUndefined();
 		expect(store.loadCharte("gone")).toBeNull();
-		expect(listener).toHaveBeenCalledWith({ name: "gone", css: "" });
+		expect(listener).toHaveBeenCalledWith({ name: "gone" });
 		cleanup();
 	});
 

--- a/packages/server/src/tools/chartes.ts
+++ b/packages/server/src/tools/chartes.ts
@@ -234,7 +234,7 @@ function runDelete(args: Args, store: Store, bus: Bus) {
 	if (!args.name) return text("name is required for action=delete", true);
 	const deleted = store.deleteCharte(args.name);
 	if (!deleted) return text(`Charte not found: "${args.name}"`, true);
-	bus.emit("charte:updated", { name: args.name, css: "" });
+	bus.emit("charte:removed", { name: args.name });
 	return text(`Charte "${args.name}" deleted`);
 }
 

--- a/packages/shared/src/ws.ts
+++ b/packages/shared/src/ws.ts
@@ -5,6 +5,19 @@
  * opaque on domain payloads. The `doc` field on `state` is whatever
  * `documents.lightView()` emits — that projection diverges between server
  * persistence and client UI, so we deliberately keep it `unknown` here.
+ *
+ * Naming convention:
+ *   - client → server: `verb_resource` — the client asks the server to
+ *     perform an action (`load_document`, `update_meta`, `delete_asset`).
+ *     Partial-update messages (`update_meta`, `update_charte_meta`,
+ *     `update_asset_meta`) carry only fields to merge; omitted fields are
+ *     preserved server-side. Full-record writes use a different verb
+ *     (`charte_save`).
+ *   - server → client: notification names — the server announces a fact.
+ *     Either a noun (`state`, `toast`, `activity`) or `noun_pastVerb`
+ *     (`charte_updated`, `charte_removed`, `assets_changed`, `doc_removed`).
+ *   - RPC pairs use `<name>_request` / `<name>_response` (see
+ *     `check_layout_*`).
  */
 
 // ============================================================
@@ -35,8 +48,15 @@ export interface WsCharteUpdatedMessage {
 	css: string;
 }
 
-export interface WsRemoveDocMessage {
-	type: "remove_doc";
+/** Distinct from `charte_updated`: announces deletion. Replaces the legacy
+ * overload where `charte_updated` with `css: ""` signalled removal. */
+export interface WsCharteRemovedMessage {
+	type: "charte_removed";
+	name: string;
+}
+
+export interface WsDocRemovedMessage {
+	type: "doc_removed";
 	name: string;
 }
 
@@ -78,7 +98,8 @@ export type WsServerMessage =
 	| WsStateMessage
 	| WsToastMessage
 	| WsCharteUpdatedMessage
-	| WsRemoveDocMessage
+	| WsCharteRemovedMessage
+	| WsDocRemovedMessage
 	| WsAckMessagesMessage
 	| WsReloadMessage
 	| WsActivityMessage
@@ -149,13 +170,51 @@ export interface WsDeleteAssetMessage {
 }
 
 /**
+ * Partial update of an asset's metadata row. Mirrors `update_meta` for docs:
+ * only fields explicitly set are written; omitted fields are preserved.
+ * Identity is `filename` — renaming an asset is not part of this envelope.
+ */
+export interface WsUpdateAssetMetaMessage {
+	type: "update_asset_meta";
+	filename: string;
+	title?: string;
+	description?: string;
+	category?: string;
+	tags?: string[];
+	credit?: string;
+	orientation?: string;
+}
+
+/**
  * Write a full charte record. Name is the identity — renaming is not part of
  * this envelope; clients wanting to rename should `charte_save` under the new
  * name and then call `maket_charte delete` on the old one. Tokens/voice/rules
- * fully replace the stored values (no partial merge).
+ * fully replace the stored values (no partial merge — use
+ * `update_charte_meta` for partial edits).
  */
 export interface WsCharteSaveMessage {
 	type: "charte_save";
+	name: string;
+	description?: string;
+	tokens?: Record<string, Record<string, string>>;
+	voice?: {
+		personality?: string[];
+		formality?: string;
+		do?: string[];
+		dont?: string[];
+		vocabulary?: string[];
+	};
+	rules?: Record<string, string>;
+}
+
+/**
+ * Partial update of a charte. Mirrors `update_meta` for docs and
+ * `update_asset_meta` for assets: only fields explicitly set are merged;
+ * omitted fields are preserved server-side. Use this for editing
+ * description/voice/rules without rebuilding tokens, or vice versa.
+ */
+export interface WsUpdateCharteMetaMessage {
+	type: "update_charte_meta";
 	name: string;
 	description?: string;
 	tokens?: Record<string, Record<string, string>>;
@@ -267,7 +326,9 @@ export type WsClientMessage =
 	| WsUpdateCanvasMessage
 	| WsUpdateMetaMessage
 	| WsDeleteAssetMessage
+	| WsUpdateAssetMetaMessage
 	| WsCharteSaveMessage
+	| WsUpdateCharteMetaMessage
 	| WsPageGoMessage
 	| WsClearCanvasMessage
 	| WsTextEditMessage

--- a/packages/shared/src/ws.ts
+++ b/packages/shared/src/ws.ts
@@ -173,6 +173,15 @@ export interface WsDeleteAssetMessage {
  * Partial update of an asset's metadata row. Mirrors `update_meta` for docs:
  * only fields explicitly set are written; omitted fields are preserved.
  * Identity is `filename` — renaming an asset is not part of this envelope.
+ *
+ * Clear-vs-preserve semantics (shared by `update_meta` and
+ * `update_charte_meta` — same gap): this verb does NOT support clearing an
+ * existing scalar value. Empty strings collapse to NULL through
+ * `store.saveAsset`'s `|| null` fallback, then the SQL UPSERT's `COALESCE`
+ * preserves the prior row value. `tags: []` is treated as "preserve" by
+ * the upsert's `CASE WHEN excluded.tags != '[]'`. To clear a stored value
+ * today, callers must round-trip through MCP delete + re-import. A
+ * dedicated clear-fields contract is tracked as a follow-up.
  */
 export interface WsUpdateAssetMetaMessage {
 	type: "update_asset_meta";


### PR DESCRIPTION
## Summary

Locks in one pattern for metadata edits across **doc / charte / asset** and clears the asymmetries that surfaced before adding the image-metadata UI feature. ESAC cartography confirmed the surface is small enough for a minimal refactor (5 real consumer files of the WS unions, every individual message interface at `refs:0`) — the previously-discussed CQRS layer would have multiplied concept count by ~4× without solving anything user-visible.

- **WS contract**: add partial-update messages `update_charte_meta` and `update_asset_meta` (mirror of `update_meta` for docs); split the overloaded `charte_updated { css: "" }` into a distinct `charte_removed` notification + `charte:removed` bus event; rename outbound `remove_doc` → `doc_removed` to match the documented `noun_pastVerb` convention.
- **Cleanup**: drop the legacy `metadata.json` sidecar (append-only, never read; SQLite `assets` is canonical); clarify in code that `imageToken`/`charteToken` are *proof-of-read* tokens, not OCC (per-process secret resets on restart).

A second commit registers the `esac` MCP server in `.mcp.json` using `${ESAC_TOKEN}` env-var substitution so no secret lands in the repo.

## Test plan

- [x] `npm run quality` — lint + typecheck + 596 tests + version-check, all green
- [x] +5 unit tests on `update_charte_meta` / `update_asset_meta` (merge semantics, missing-target rejection, runtime payload validation)
- [x] Live MCP smoke against the running dev server:
  - `maket_charte set` → `view` → `delete` → `list` (deletion path now goes through `charte:removed`)
  - `maket_image view` → `meta` (partial title-only update preserves description, tags, credit, dimensions, orientation; token unchanged after no-op modification → confirms proof-of-read semantics, not OCC)
- [ ] UI consumers of the new `update_*_meta` verbs land in the next PR (image-metadata editor); the contract is dormant on this branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)