### PR TITLE
chore(bundle): drop unused MAKET_BUNDLE_VERSION export

### DIFF
--- a/packages/server/src/lib/maket-format.ts
+++ b/packages/server/src/lib/maket-format.ts
@@ -24,10 +24,7 @@ import type { Charte, Document } from "../types.js";
 export const MAKET_BUNDLE_KIND = "maket-bundle";
 export const MAKET_BUNDLE_EXT = ".maket";
 
-/** Highest bundle version this server can emit. */
-export const MAKET_BUNDLE_VERSION = 2;
-
-/** Versions this server can read. Increment both on format changes. */
+/** Versions this server can read. Increment on format changes. */
 const SUPPORTED_VERSIONS = new Set([1, 2]);
 
 export interface BundleDocument {


### PR DESCRIPTION
## Summary
- `MAKET_BUNDLE_VERSION` (`packages/server/src/lib/maket-format.ts:28`) was exported but never read — `encodeBundleV1` / `encodeBundleV2` pass version literals (`1` / `2`) directly to `buildManifest`, and `SUPPORTED_VERSIONS` is the only authoritative read list.
- The export's docstring claimed "highest bundle version this server can emit", but bumping it would not change what's written to `manifest.json` — silent drift if anyone trusted the const.
- Picked suppression over usage: no downstream consumer exists, the only call site is local, and a dead export is worse than no export.

## Test plan
- [x] `npm run quality` (lint + typecheck + 614 tests) — green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)