### PR TITLE
fix(wire): partial-update verbs honour explicit clear (closes #19)

### DIFF
--- a/packages/server/src/services/store.ts
+++ b/packages/server/src/services/store.ts
@@ -226,7 +226,15 @@ export class DocumentStore implements Store {
 			"DELETE FROM chartes WHERE name = ?",
 		);
 
-		// Assets
+		// Assets — partial-update UPSERT.
+		//
+		// `coalesce(excluded.X, assets.X)` is the "preserve on null" pattern for
+		// nullable text/integer columns: pass NULL to keep the prior value, any
+		// real value (including `''`) to write. The `tags` column is NOT NULL,
+		// so it cannot use that pattern; instead `$tags_set = 1` flags an
+		// explicit write and `0` flags preserve. With this split, every field
+		// follows the rule "only `undefined` from the JS caller preserves" —
+		// `''` and `[]` clear, matching the partial-update WS verb contract.
 		this.stmtAssetUpsert = this.db.prepare(`
       INSERT INTO assets (filename, title, description, category, tags, credit, width, height, orientation, created_at)
       VALUES ($filename, $title, $description, $category, $tags, $credit, $width, $height, $orientation, datetime('now'))
@@ -234,7 +242,7 @@ export class DocumentStore implements Store {
         title = coalesce(excluded.title, assets.title),
         description = coalesce(excluded.description, assets.description),
         category = coalesce(excluded.category, assets.category),
-        tags = CASE WHEN excluded.tags != '[]' THEN excluded.tags ELSE assets.tags END,
+        tags = CASE WHEN $tags_set = 1 THEN excluded.tags ELSE assets.tags END,
         credit = coalesce(excluded.credit, assets.credit),
         width = coalesce(excluded.width, assets.width),
         height = coalesce(excluded.height, assets.height),
@@ -365,16 +373,24 @@ export class DocumentStore implements Store {
 	// ---- Assets CRUD ----
 
 	saveAsset(a: AssetInput): void {
+		// `?? null` (not `|| null`) so that empty string / 0 / `[]` reach the
+		// SQL layer as themselves and clear the column, instead of collapsing
+		// to NULL which the COALESCE would then preserve. Only `undefined`
+		// preserves — that is the partial-update contract.
+		const tagsSet = a.tags !== undefined ? 1 : 0;
+		const tagsValue =
+			typeof a.tags === "string" ? a.tags : JSON.stringify(a.tags ?? []);
 		this.stmtAssetUpsert.run({
 			filename: a.filename,
-			title: a.title || null,
-			description: a.description || null,
-			category: a.category || null,
-			tags: typeof a.tags === "string" ? a.tags : JSON.stringify(a.tags || []),
-			credit: a.credit || null,
-			width: a.width || null,
-			height: a.height || null,
-			orientation: a.orientation || null,
+			title: a.title ?? null,
+			description: a.description ?? null,
+			category: a.category ?? null,
+			tags: tagsValue,
+			tags_set: tagsSet,
+			credit: a.credit ?? null,
+			width: a.width ?? null,
+			height: a.height ?? null,
+			orientation: a.orientation ?? null,
 		});
 	}
 

--- a/packages/server/src/services/ws-handler.test.ts
+++ b/packages/server/src/services/ws-handler.test.ts
@@ -357,6 +357,30 @@ describe("ws-handler — document and canvas flows", () => {
 		dispose();
 	});
 
+	it("update_meta clears prose fields when the caller sends ``", () => {
+		const { store, documents, handler, dispose } = fixture();
+		const doc = makeDoc("meta-clear");
+		doc.meta = { designNotes: "kept", teamNotes: "kept" };
+		store.saveDoc(doc);
+		documents.loadAll();
+
+		handler(
+			{
+				type: "update_meta",
+				docName: "meta-clear",
+				designNotes: "",
+				teamNotes: "",
+			},
+			STUB_WS,
+		);
+
+		expect(documents.resolve("meta-clear")?.meta).toMatchObject({
+			designNotes: "",
+			teamNotes: "",
+		});
+		dispose();
+	});
+
 	it("page_go switches the active page and clear_canvas resets the current page", () => {
 		const { store, documents, bus, handler, dispose } = fixture();
 		const doc = createDocument({
@@ -658,6 +682,29 @@ describe("ws-handler — text editing", () => {
 		dispose();
 	});
 
+	it("update_charte_meta clears description when the caller sends ``", () => {
+		const { store, handler, dispose } = fixture();
+		store.saveCharte({
+			name: "brand",
+			description: "kept",
+			tokens: { color: { primary: "#2563EB" } },
+		});
+
+		handler(
+			{
+				type: "update_charte_meta",
+				name: "brand",
+				description: "",
+			},
+			STUB_WS,
+		);
+
+		const stored = store.loadCharte("brand");
+		expect(stored?.description).toBe("");
+		expect(stored?.tokens.color?.primary).toBe("#2563EB");
+		dispose();
+	});
+
 	it("update_charte_meta toasts when the charte does not exist (no creation)", () => {
 		const { store, bus, handler, dispose } = fixture();
 		const toast = vi.fn();
@@ -708,6 +755,60 @@ describe("ws-handler — text editing", () => {
 		expect(toast).toHaveBeenCalledWith(
 			expect.objectContaining({ level: "error" }),
 		);
+		dispose();
+	});
+
+	it("update_asset_meta clears string fields when the caller sends ``", () => {
+		const { store, bus, assetsDir, handler, dispose } = fixture();
+		writeFileSync(join(assetsDir, "hero.png"), "px");
+		store.saveAsset({
+			filename: "hero.png",
+			title: "Old title",
+			description: "Old desc",
+			credit: "@photographer",
+		});
+		const changed = vi.fn();
+		bus.on("assets:changed", changed);
+
+		handler(
+			{
+				type: "update_asset_meta",
+				filename: "hero.png",
+				title: "",
+				credit: "",
+			},
+			STUB_WS,
+		);
+
+		const row = store.loadAsset("hero.png");
+		expect(row?.title).toBe("");
+		expect(row?.credit).toBe("");
+		expect(row?.description).toBe("Old desc");
+		expect(changed).toHaveBeenCalledWith({});
+		dispose();
+	});
+
+	it("update_asset_meta clears tags when the caller sends []", () => {
+		const { store, assetsDir, handler, dispose } = fixture();
+		writeFileSync(join(assetsDir, "hero.png"), "px");
+		store.saveAsset({
+			filename: "hero.png",
+			title: "Hero",
+			tags: ["a", "b"],
+		});
+
+		handler(
+			{
+				type: "update_asset_meta",
+				filename: "hero.png",
+				tags: [],
+			},
+			STUB_WS,
+		);
+
+		const row = store.loadAsset("hero.png");
+		expect(row?.tags).toEqual([]);
+		expect(row?.title).toBe("Hero");
 		dispose();
 	});
 

--- a/packages/server/src/services/ws-handler.ts
+++ b/packages/server/src/services/ws-handler.ts
@@ -162,12 +162,16 @@ export function createWsHandler(deps: WsHandlerDeps): WsMessageHandler {
 					break;
 				}
 				if (!d.meta) d.meta = {};
-				if (msg.designNotes != null) d.meta.designNotes = msg.designNotes;
-				if (msg.teamNotes != null) d.meta.teamNotes = msg.teamNotes;
-				if (msg.rating != null)
+				// Use `!== undefined` (not `!= null`) so `""` reaches the assignment
+				// and clears the field — partial-update contract: only `undefined`
+				// preserves. Category falls back to "general" when cleared because
+				// docs cannot be category-less in this schema.
+				if (msg.designNotes !== undefined) d.meta.designNotes = msg.designNotes;
+				if (msg.teamNotes !== undefined) d.meta.teamNotes = msg.teamNotes;
+				if (msg.rating !== undefined)
 					d.meta.rating = Math.max(0, Math.min(5, Number(msg.rating) || 0));
-				if (msg.charte != null) d.meta.charte = msg.charte;
-				if (msg.category != null) d.category = msg.category || "general";
+				if (msg.charte !== undefined) d.meta.charte = msg.charte;
+				if (msg.category !== undefined) d.category = msg.category || "general";
 				documents.persist(d.name);
 				bus.emit("meta:updated", { docName: d.name });
 				break;
@@ -278,8 +282,9 @@ export function createWsHandler(deps: WsHandlerDeps): WsMessageHandler {
 					});
 					break;
 				}
-				// store.saveAsset uses UPSERT with COALESCE on every field, so
-				// passing only the fields in msg preserves the others.
+				// store.saveAsset preserves fields whose value is `undefined`
+				// and writes everything else (including `""` / `[]` for
+				// explicit clear). Forwarding msg.* directly is the contract.
 				store.saveAsset({
 					filename,
 					title: msg.title,

--- a/packages/shared/src/ws.ts
+++ b/packages/shared/src/ws.ts
@@ -174,14 +174,11 @@ export interface WsDeleteAssetMessage {
  * only fields explicitly set are written; omitted fields are preserved.
  * Identity is `filename` — renaming an asset is not part of this envelope.
  *
- * Clear-vs-preserve semantics (shared by `update_meta` and
- * `update_charte_meta` — same gap): this verb does NOT support clearing an
- * existing scalar value. Empty strings collapse to NULL through
- * `store.saveAsset`'s `|| null` fallback, then the SQL UPSERT's `COALESCE`
- * preserves the prior row value. `tags: []` is treated as "preserve" by
- * the upsert's `CASE WHEN excluded.tags != '[]'`. To clear a stored value
- * today, callers must round-trip through MCP delete + re-import. A
- * dedicated clear-fields contract is tracked as a follow-up.
+ * Clear-vs-preserve semantics: only `undefined` preserves. Pass `""` to clear
+ * a string field, `[]` to clear tags. The server-side `saveAsset` honours
+ * this via `?? null` for prose fields plus a `$tags_set` flag for tags;
+ * symmetric with `update_charte_meta` (which merges in JS) and
+ * `update_meta` (`!= null` checks let `""` through for prose fields).
  */
 export interface WsUpdateAssetMetaMessage {
 	type: "update_asset_meta";

--- a/packages/shared/src/ws.ts
+++ b/packages/shared/src/ws.ts
@@ -170,15 +170,10 @@ export interface WsDeleteAssetMessage {
 }
 
 /**
- * Partial update of an asset's metadata row. Mirrors `update_meta` for docs:
- * only fields explicitly set are written; omitted fields are preserved.
- * Identity is `filename` — renaming an asset is not part of this envelope.
- *
- * Clear-vs-preserve semantics: only `undefined` preserves. Pass `""` to clear
- * a string field, `[]` to clear tags. The server-side `saveAsset` honours
- * this via `?? null` for prose fields plus a `$tags_set` flag for tags;
- * symmetric with `update_charte_meta` (which merges in JS) and
- * `update_meta` (`!= null` checks let `""` through for prose fields).
+ * Partial update of an asset's metadata row. Mirrors `update_meta` for docs
+ * and `update_charte_meta` for chartes — same clear-vs-preserve rule across
+ * the three: only `undefined` preserves; `""` clears a string field, `[]`
+ * clears tags. Identity is `filename` (renames are out of envelope).
  */
 export interface WsUpdateAssetMetaMessage {
 	type: "update_asset_meta";


### PR DESCRIPTION
## Summary
Locks in **one** symmetric clear-vs-preserve rule across the three partial-update WS verbs:

> Only `undefined` preserves. `""`, `0`, `[]` clear.

The prior implementation was inconsistent:
- **`update_asset_meta`** silently couldn't clear anything — `store.saveAsset`'s `a.X \|\| null` collapsed empty strings to `NULL`, then the SQL `COALESCE` preserved the prior value. Tags hit a separate `excluded.tags != '[]'` sentinel that read `[]` as "preserve".
- **`update_meta`** used `!= null` checks — prose fields *did* let `""` through, but `null` and `undefined` were both treated as preserve (loose-equality smell).
- **`update_charte_meta`** was already correct (JS-side merge over a JSON blob), but had no test asserting clear.

## Changes

- `services/store.ts` — `saveAsset` switches `\|\|` → `??` for prose fields. Tags use a `$tags_set` flag in the UPSERT (`CASE WHEN \$tags_set = 1 THEN excluded.tags ELSE assets.tags END`), replacing the `'[]'`-sentinel.
- `services/ws-handler.ts` — `update_meta` switches `!= null` → `!== undefined`. Stale comment about UPSERT/COALESCE preserving updated.
- `shared/src/ws.ts` — `WsUpdateAssetMetaMessage` docstring rewritten to describe the new semantics; the follow-up note removed.

## Caveats
- Doc category still falls back to `"general"` on clear — docs cannot be category-less in this schema. Documented inline.
- A client sending `rating: null` (off-contract — TS says `number`) now writes `0` instead of being silently skipped. Edge case; the new rule is more predictable.

## Test plan
- [x] `npm run quality` — 637 tests (+4), lint, typecheck, version-check all green.
- New WS-handler tests: clear `title: ""`, clear `tags: []`, clear charte `description: ""`, clear doc prose `designNotes: ""` / `teamNotes: ""`.

Closes #19.

🤖 Generated with [Claude Code](https://claude.com/claude-code)