### PR TITLE
fix: preserve datasets during layout refresh

### DIFF
--- a/packages/client/src/store/ws.integration.test.ts
+++ b/packages/client/src/store/ws.integration.test.ts
@@ -1,4 +1,5 @@
 import type {
+	Collection,
 	LayoutCheckResult,
 	WorkspaceCommand,
 	WorkspaceSignal,
@@ -78,6 +79,22 @@ function summary(name: string): DocSummary {
 		elementCount: 0,
 	};
 }
+
+const clientsCollection: Collection = {
+	name: "clients",
+	schema: {
+		type: "object",
+		properties: { client_name: { type: "string" } },
+		required: ["client_name"],
+	},
+	members: [
+		{
+			id: "member_1",
+			position: 0,
+			data: { client_name: "Acme" },
+		},
+	],
+};
 
 // Re-import the store and ws module in isolation for each test so
 // `let ws` / `initialStateReceived` / `pendingLoadDoc` inside ws.ts start fresh.
@@ -254,6 +271,28 @@ describe("state message", () => {
 		const s = useStore.getState();
 		expect(s.docList).toHaveLength(2);
 		expect(s.docs.size).toBe(0);
+	});
+
+	it("preserves collections when a layout state refresh omits them", async () => {
+		const { initWs, useStore } = await freshWsModule();
+		initWs();
+		MockWebSocket.last().open();
+
+		MockWebSocket.last().emit({
+			type: "state",
+			doc: doc("alpha"),
+			docList: [summary("alpha")],
+			collections: [clientsCollection],
+			charteCss: "",
+		});
+		MockWebSocket.last().emit({
+			type: "state",
+			doc: doc("alpha"),
+			docList: [summary("alpha")],
+			charteCss: "",
+		});
+
+		expect(useStore.getState().collections).toEqual([clientsCollection]);
 	});
 });
 

--- a/packages/client/src/store/ws.ts
+++ b/packages/client/src/store/ws.ts
@@ -337,8 +337,9 @@ function applyStateMessage(
 ): void {
 	const doc = msg.doc as Document | null;
 	const docList = (msg.docList ?? []) as DocSummary[];
-	const collections = (msg.collections ?? []) as Collection[];
-	useStore.getState().setCollections(collections);
+	if (msg.collections !== undefined) {
+		useStore.getState().setCollections(msg.collections as Collection[]);
+	}
 	if (msg.charteCss) ensureCharteFonts(msg.charteCss);
 	if (!doc) {
 		useStore.setState({ docList });


### PR DESCRIPTION
Fixes #24.

A layout-only WebSocket state refresh omits collections. The client now treats that as a partial update instead of clearing the dataset store.

Validation: npm run quality.