### PR TITLE
feat(site): add copyable agent install prompt

### DIFF
--- a/docs/fr/index.html
+++ b/docs/fr/index.html
@@ -282,6 +282,7 @@
       padding: 0.9rem 1.25rem;
       border: 1px solid rgba(251, 250, 246, 0.3);
       border-radius: 999px;
+      font-family: inherit;
       font-size: var(--type-label);
       font-weight: 600;
       transition:
@@ -289,6 +290,11 @@
         background 180ms ease,
         border-color 180ms ease,
         transform 180ms ease;
+    }
+
+    .button[data-copy-install] {
+      min-width: 12rem;
+      cursor: pointer;
     }
 
     .button:hover,
@@ -1385,12 +1391,34 @@
           <span class="section-index">06 — Installation</span>
           <h2>Connectez Maket à votre agent<span class="dot">.</span></h2>
           <p>
-            Choisissez votre client, lancez les commandes ci-contre, puis ouvrez
-            l’interface.
+            Copiez le prompt prêt à l’emploi dans Codex, Claude ou Gemini. Votre
+            agent installera, démarrera et vérifiera Maket pour vous.
           </p>
           <div class="actions">
-            <a class="button button--primary" href="https://github.com/ng-galien/maket#install" target="_blank" rel="noopener">Lire le guide complet ↗</a>
+            <button
+              class="button button--primary"
+              type="button"
+              data-copy-install
+              data-copy-target="agent-install-prompt"
+              data-label="Copier les instructions"
+              data-success-label="Copié"
+              data-error-label="Échec de la copie"
+            ><span aria-live="polite">Copier les instructions</span></button>
+            <a class="button button--ghost" href="https://github.com/ng-galien/maket#install" target="_blank" rel="noopener">Lire le guide complet ↗</a>
           </div>
+          <script type="text/plain" id="agent-install-prompt">Installe Maket dans cet environnement et réalise toute la configuration de bout en bout.
+
+1. Vérifie que Node.js 22 ou une version plus récente est disponible.
+2. Détermine si le client agent actuel est Claude Code, Codex ou Gemini. Lance ensuite :
+   npx -y @ng-galien/maket install <claude|codex|gemini> --apply
+3. Préserve toutes les entrées et tous les serveurs MCP déjà configurés.
+4. Démarre Maket :
+   npx -y @ng-galien/maket start
+5. Lance `npx -y @ng-galien/maket doctor` et vérifie que le serveur MCP Maket et ses outils sont accessibles depuis ce client.
+6. Ouvre l’interface avec `npx -y @ng-galien/maket open`. Si le client doit être redémarré, indique-moi précisément quoi relancer.
+7. Résume les modifications effectuées, le résultat des vérifications et l’URL locale de Maket.
+
+Ne te contente pas d’expliquer les commandes : réalise l’installation et les vérifications. Demande mon accord avant toute action nécessitant une autorisation.</script>
         </div>
 
         <div class="reveal">
@@ -1467,6 +1495,52 @@
       },
       { passive: true }
     );
+
+    async function writeToClipboard(value) {
+      if (navigator.clipboard?.writeText) {
+        try {
+          await navigator.clipboard.writeText(value);
+          return;
+        } catch {
+          // Fall through for browsers that expose the API but deny access.
+        }
+      }
+
+      const textarea = document.createElement('textarea');
+      textarea.value = value;
+      textarea.setAttribute('readonly', '');
+      textarea.style.position = 'fixed';
+      textarea.style.opacity = '0';
+      document.body.append(textarea);
+      textarea.select();
+      let copied = false;
+      try {
+        copied = document.execCommand('copy');
+      } finally {
+        textarea.remove();
+      }
+      if (!copied) throw new Error('Clipboard copy failed');
+    }
+
+    for (const button of document.querySelectorAll('[data-copy-install]')) {
+      button.addEventListener('click', async () => {
+        const target = document.getElementById(button.dataset.copyTarget);
+        const label = button.querySelector('[aria-live]');
+        if (!target || !label) return;
+
+        try {
+          await writeToClipboard(target.textContent.trim());
+          button.dataset.state = 'copied';
+          label.textContent = button.dataset.successLabel;
+          window.setTimeout(() => {
+            delete button.dataset.state;
+            label.textContent = button.dataset.label;
+          }, 2400);
+        } catch {
+          label.textContent = button.dataset.errorLabel;
+        }
+      });
+    }
   </script>
 </body>
 </html>

--- a/docs/index.html
+++ b/docs/index.html
@@ -281,6 +281,7 @@
       padding: 0.9rem 1.25rem;
       border: 1px solid rgba(251, 250, 246, 0.3);
       border-radius: 999px;
+      font-family: inherit;
       font-size: var(--type-label);
       font-weight: 600;
       transition:
@@ -288,6 +289,11 @@
         background 180ms ease,
         border-color 180ms ease,
         transform 180ms ease;
+    }
+
+    .button[data-copy-install] {
+      min-width: 12rem;
+      cursor: pointer;
     }
 
     .button:hover,
@@ -1380,10 +1386,32 @@
         <div class="install__copy reveal">
           <span class="section-index">06 — Installation</span>
           <h2>Connect Maket to your agent<span class="dot">.</span></h2>
-          <p>Choose your client, run the commands, then open the interface.</p>
+          <p>Copy the ready-made prompt into Codex, Claude, or Gemini. Your agent will install, start, and verify Maket for you.</p>
           <div class="actions">
-            <a class="button button--primary" href="https://github.com/ng-galien/maket#install" target="_blank" rel="noopener">Read the full guide ↗</a>
+            <button
+              class="button button--primary"
+              type="button"
+              data-copy-install
+              data-copy-target="agent-install-prompt"
+              data-label="Copy instructions"
+              data-success-label="Copied"
+              data-error-label="Copy failed"
+            ><span aria-live="polite">Copy instructions</span></button>
+            <a class="button button--ghost" href="https://github.com/ng-galien/maket#install" target="_blank" rel="noopener">Read the full guide ↗</a>
           </div>
+          <script type="text/plain" id="agent-install-prompt">Install Maket in this environment and complete the setup end to end.
+
+1. Check that Node.js 22 or newer is available.
+2. Determine whether the current agent client is Claude Code, Codex, or Gemini. Then run:
+   npx -y @ng-galien/maket install <claude|codex|gemini> --apply
+3. Preserve every existing MCP configuration entry and server.
+4. Start Maket:
+   npx -y @ng-galien/maket start
+5. Run `npx -y @ng-galien/maket doctor` and verify that the Maket MCP server and its tools are reachable from this client.
+6. Open the interface with `npx -y @ng-galien/maket open`. If the client must be restarted, tell me exactly what to restart.
+7. Report what you changed, the verification result, and the local Maket URL.
+
+Do not stop at explaining the commands: perform the installation and verification. Ask before any permission-sensitive action.</script>
         </div>
 
         <div class="reveal">
@@ -1460,6 +1488,52 @@
       },
       { passive: true }
     );
+
+    async function writeToClipboard(value) {
+      if (navigator.clipboard?.writeText) {
+        try {
+          await navigator.clipboard.writeText(value);
+          return;
+        } catch {
+          // Fall through for browsers that expose the API but deny access.
+        }
+      }
+
+      const textarea = document.createElement('textarea');
+      textarea.value = value;
+      textarea.setAttribute('readonly', '');
+      textarea.style.position = 'fixed';
+      textarea.style.opacity = '0';
+      document.body.append(textarea);
+      textarea.select();
+      let copied = false;
+      try {
+        copied = document.execCommand('copy');
+      } finally {
+        textarea.remove();
+      }
+      if (!copied) throw new Error('Clipboard copy failed');
+    }
+
+    for (const button of document.querySelectorAll('[data-copy-install]')) {
+      button.addEventListener('click', async () => {
+        const target = document.getElementById(button.dataset.copyTarget);
+        const label = button.querySelector('[aria-live]');
+        if (!target || !label) return;
+
+        try {
+          await writeToClipboard(target.textContent.trim());
+          button.dataset.state = 'copied';
+          label.textContent = button.dataset.successLabel;
+          window.setTimeout(() => {
+            delete button.dataset.state;
+            label.textContent = button.dataset.label;
+          }, 2400);
+        } catch {
+          label.textContent = button.dataset.errorLabel;
+        }
+      });
+    }
   </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add a one-click agent installation prompt to the English and French homepages
- guide Codex, Claude, or Gemini through install, startup, diagnostics, and verification
- preserve existing MCP configuration and provide accessible copied/error feedback
- keep the manual installation commands and guide alongside the new action

## Validation
- 
> maket@1.4.4 typecheck
> tsc -b packages/shared packages/server packages/stdio-bridge packages/client
- 
> maket@1.4.4 test
> vitest run


 RUN  v4.1.4 /Users/alexandreboyer/dev/projects/mcp-maket


 Test Files  74 passed | 1 skipped (75)
      Tests  732 passed | 2 skipped (734)
   Start at  19:16:56
   Duration  6.54s (transform 3.03s, setup 16.53s, import 15.43s, tests 3.63s, environment 8.37s) (732 passed, 2 skipped)
- 
> maket@1.4.4 version:check
> node scripts/check-versions.mjs

check-versions: ok (packages, lockfile, and registry metadata at 1.4.4)
- static DOM checks for both localized prompts
- in-app browser verification for English, French, and mobile layout

Closes #36