### PR TITLE
Fix pull-request CI run finalization

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,61 +69,6 @@ jobs:
           path: coverage/
           if-no-files-found: error
 
-  coverage-badge:
-    name: Publish coverage badge
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-    needs: quality
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-    concurrency:
-      group: coverage-badge-main
-      cancel-in-progress: false
-
-    steps:
-      - uses: actions/checkout@v7
-        with:
-          fetch-depth: 0
-          ref: main
-
-      - uses: actions/setup-node@v7
-        with:
-          node-version: "24"
-
-      - name: Download validated coverage
-        uses: actions/download-artifact@v8
-        with:
-          name: coverage-report
-          path: coverage/
-
-      - name: Generate coverage badge
-        run: node scripts/coverage-badge.mjs
-
-      - name: Commit coverage badge
-        shell: bash
-        run: |
-          if git diff --quiet -- .github/badges/coverage.json; then
-            exit 0
-          fi
-          base_sha="$(git rev-parse HEAD)"
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add .github/badges/coverage.json
-          git commit -m "chore(ci): update coverage badge [skip ci]"
-          for attempt in 1 2 3; do
-            if git push origin HEAD:main; then
-              exit 0
-            fi
-            git fetch origin main
-            if [[ "$(git rev-parse origin/main)" != "$base_sha" ]]; then
-              echo "::notice::main advanced; a newer CI run will publish its coverage badge"
-              exit 0
-            fi
-            echo "::warning::coverage badge push attempt $attempt failed; retrying"
-          done
-          echo "::error::coverage badge push failed while main remained unchanged"
-          exit 1
-
   e2e:
     name: End-to-end (Chromium)
     runs-on: ubuntu-latest

--- a/.github/workflows/coverage-badge.yml
+++ b/.github/workflows/coverage-badge.yml
@@ -1,0 +1,71 @@
+name: Publish coverage badge
+
+on:
+  workflow_run:
+    workflows: [CI]
+    types: [completed]
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  publish:
+    if: >-
+      github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.event == 'push'
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: write
+    concurrency:
+      group: coverage-badge-main
+      cancel-in-progress: false
+
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+          ref: main
+
+      - uses: actions/setup-node@v7
+        with:
+          node-version: "24"
+
+      - name: Download validated coverage
+        uses: actions/download-artifact@v8
+        with:
+          name: coverage-report
+          path: ${{ runner.temp }}/coverage
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Generate coverage badge
+        run: >-
+          node scripts/coverage-badge.mjs
+          "${{ runner.temp }}/coverage/coverage-summary.json"
+
+      - name: Commit coverage badge
+        shell: bash
+        run: |
+          if git diff --quiet -- .github/badges/coverage.json; then
+            exit 0
+          fi
+          base_sha="$(git rev-parse HEAD)"
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add .github/badges/coverage.json
+          git commit -m "chore(ci): update coverage badge [skip ci]"
+          for attempt in 1 2 3; do
+            if git push origin HEAD:main; then
+              exit 0
+            fi
+            git fetch origin main
+            if [[ "$(git rev-parse origin/main)" != "$base_sha" ]]; then
+              echo "::notice::main advanced; a newer CI run will publish its coverage badge"
+              exit 0
+            fi
+            echo "::warning::coverage badge push attempt $attempt failed; retrying"
+          done
+          echo "::error::coverage badge push failed while main remained unchanged"
+          exit 1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,10 @@ from the git log since the last tag — paste into `[Unreleased]` and edit.
   coverage-enforced quality contract as local development and a separate
   Playwright suite in Chromium. Installable-package smoke tests remain a
   release gate.
+- **Coverage badge publication no longer participates in pull-request CI.** A
+  separate write-scoped workflow consumes the validated artifact only after a
+  successful CI push to `main`, so pull-request runs terminate normally and
+  remain read-only.
 
 ## [1.6.0] — 2026-08-09
 


### PR DESCRIPTION
## Summary

- remove coverage badge publication from pull-request CI entirely
- keep PR validation limited to the read-only quality and Playwright jobs
- publish the badge from a separate workflow after successful CI pushes to `main`

## Root cause

The badge publisher was represented as a job inside the PR workflow and skipped at job level. Both validation jobs completed, but the PR workflow could remain reported as `in_progress`. Fresh `main` runs, where the badge job executed, terminated normally.

## Validation

- YAML syntax validated for both workflows
- coverage artifact path and badge generation validated locally
- `npm run quality` — 104 files and 997 tests passed
- independent review completed with no actionable findings

Closes #60
