### PR TITLE
fix(workspace): make document renames atomic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,14 @@ from the git log since the last tag — paste into `[Unreleased]` and edit.
 
 ## [Unreleased]
 
+## [1.7.2] — 2026-08-14
+
+### Fixed
+
+- Keep a renamed document as a single workspace instance across Canvas and
+  Reader, preserving each window's focus, active page, and annotations without
+  requiring a browser refresh.
+
 ## [1.7.1] — 2026-08-12
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "maket",
-  "version": "1.7.1",
+  "version": "1.7.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "maket",
-      "version": "1.7.1",
+      "version": "1.7.2",
       "license": "MIT",
       "workspaces": [
         "packages/*"
@@ -7995,7 +7995,7 @@
     },
     "packages/client": {
       "name": "@maket/client",
-      "version": "1.7.1",
+      "version": "1.7.2",
       "license": "MIT",
       "dependencies": {
         "@maket/shared": "*",
@@ -8029,7 +8029,7 @@
     },
     "packages/server": {
       "name": "@maket/server",
-      "version": "1.7.1",
+      "version": "1.7.2",
       "license": "MIT",
       "dependencies": {
         "@maket/shared": "*",
@@ -8054,7 +8054,7 @@
     },
     "packages/shared": {
       "name": "@maket/shared",
-      "version": "1.7.1",
+      "version": "1.7.2",
       "license": "MIT",
       "dependencies": {
         "@types/mustache": "^4.2.6",
@@ -8064,7 +8064,7 @@
     },
     "packages/stdio-bridge": {
       "name": "@maket/stdio-bridge",
-      "version": "1.7.1",
+      "version": "1.7.2",
       "license": "MIT",
       "dependencies": {
         "@maket/server": "*",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maket",
-  "version": "1.7.1",
+  "version": "1.7.2",
   "mcpName": "io.github.ng-galien/maket",
   "description": "Visual design tool for AI assistants — compose posters, flyers, labels, social posts with PDF export",
   "license": "MIT",

--- a/packages/client/e2e/documents.spec.ts
+++ b/packages/client/e2e/documents.spec.ts
@@ -103,6 +103,169 @@ test.describe("Document library", () => {
 		expect(persisted).toContain("Delivery plan approved");
 	});
 
+	for (const workspaceView of ["canvas", "reader"] as const) {
+		test(`atomically renames an annotated open document in ${workspaceView} mode`, async ({
+			context,
+			mcp,
+			page,
+		}) => {
+			const oldName = "Agent proposal draft";
+			const newName = "Agent proposal final";
+			const otherName = "Unrelated document";
+			const noteText = "Review the proposal before delivery";
+			await openWorkspace(page);
+			await createDocument(mcp, oldName);
+			await mcp.call("maket_page", {
+				action: "add",
+				doc: oldName,
+				name: "Delivery review",
+				html: '<main data-id="review-page"><h2 data-id="review-heading">Delivery review</h2></main>',
+			});
+			await createDocument(mcp, otherName);
+
+			const oldDocument = page.locator(`[data-doc="${oldName}"]`);
+			await expect(oldDocument).toBeVisible();
+			await oldDocument.locator('[data-page-view="1"]').click();
+			await expect(oldDocument.locator('[data-page-view="1"]')).toHaveAttribute(
+				"data-active-page",
+				"true",
+			);
+			const messagesButton = page.getByRole("button", {
+				name: /^(exchanges|échanges)$/i,
+			});
+			await messagesButton.click();
+			await page
+				.getByPlaceholder(/Note sur le document|Note about the document/i)
+				.fill(noteText);
+			await page.keyboard.press("Enter");
+			await expect(
+				oldDocument.locator("[data-annotation-page-marker]"),
+			).toBeVisible();
+			await messagesButton.click();
+
+			const secondPage = await context.newPage();
+			await openWorkspace(secondPage);
+			const secondOtherDocument = secondPage.locator(
+				`[data-doc="${otherName}"]`,
+			);
+			await expect(secondOtherDocument).toBeVisible();
+			await secondOtherDocument.click();
+			await expect(
+				secondOtherDocument.locator('[data-page-view="0"]'),
+			).toHaveAttribute("data-active-page", "true");
+
+			if (workspaceView === "reader") {
+				await page
+					.getByRole("button", { name: /Reading view|Vue lecture/i })
+					.click();
+				await secondPage
+					.getByRole("button", { name: /Reading view|Vue lecture/i })
+					.click();
+				await expect(
+					page.getByRole("button", { name: /^(Document)$/i }),
+				).toContainText(oldName);
+				await expect(
+					secondPage.getByRole("button", { name: /^(Document)$/i }),
+				).toContainText(otherName);
+				await expect(
+					page
+						.getByRole("navigation", {
+							name: /Reader navigation|Navigation du lecteur/i,
+						})
+						.getByRole("status"),
+				).toHaveText(/2\/2/);
+			}
+
+			await mcp.call("maket_doc", {
+				action: "rename",
+				doc: oldName,
+				name: newName,
+			});
+
+			if (workspaceView === "reader") {
+				await expect(
+					page.getByRole("button", { name: /^(Document)$/i }),
+				).toContainText(newName);
+				await expect(page.locator(`[data-doc="${newName}"]`)).toHaveCount(1);
+				await expect(page.locator(`[data-doc="${oldName}"]`)).toHaveCount(0);
+				await expect(
+					page
+						.getByRole("navigation", {
+							name: /Reader navigation|Navigation du lecteur/i,
+						})
+						.getByRole("status"),
+				).toHaveText(/2\/2/);
+				await expect(
+					secondPage.getByRole("button", { name: /^(Document)$/i }),
+				).toContainText(otherName);
+				await expect(secondPage.locator(`[data-doc="${newName}"]`)).toHaveCount(
+					0,
+				);
+				await page
+					.getByRole("button", { name: /Canvas view|Vue canevas/i })
+					.click();
+				await secondPage
+					.getByRole("button", { name: /Canvas view|Vue canevas/i })
+					.click();
+			}
+
+			for (const browserPage of [page, secondPage]) {
+				await expect(
+					browserPage.locator(`[data-doc="${newName}"]`),
+				).toHaveCount(1);
+				await expect(
+					browserPage.locator(`[data-doc="${oldName}"]`),
+				).toHaveCount(0);
+			}
+			await expect(
+				page.locator(
+					`[data-doc="${newName}"] [data-page-view="1"][data-active-page="true"]`,
+				),
+			).toBeVisible();
+			await expect(
+				secondPage.locator(
+					`[data-doc="${otherName}"] [data-page-view="0"][data-active-page="true"]`,
+				),
+			).toBeVisible();
+			await expect(
+				page.locator(`[data-doc="${newName}"] [data-annotation-page-marker]`),
+			).toBeVisible();
+			await expect(
+				secondPage.locator(
+					`[data-doc="${newName}"] [data-annotation-page-marker]`,
+				),
+			).toBeVisible();
+
+			const panel = await openDocuments(page);
+			await expect(panel.getByText(newName, { exact: true })).toHaveCount(1);
+			await expect(panel.getByText(oldName, { exact: true })).toHaveCount(0);
+			await page
+				.getByRole("button", {
+					name: /Close Documents|Fermer Documents/i,
+				})
+				.click();
+			await messagesButton.click();
+			await expect(page.getByText(noteText, { exact: true })).toHaveCount(1);
+
+			const messages = await mcp.callJson<
+				Array<{ id: string; docName?: string; text?: string }>
+			>("maket_workspace", { action: "list_messages" });
+			const annotation = messages.find((message) => message.text === noteText);
+			expect(annotation).toMatchObject({ docName: newName, text: noteText });
+			if (!annotation) throw new Error("Renamed annotation was not returned");
+			await mcp.call("maket_workspace", {
+				action: "ack_messages",
+				ids: [annotation.id],
+			});
+			await expect(messagesButton.locator("span")).toHaveCount(0);
+			await expect(
+				secondPage.locator(
+					`[data-doc="${newName}"] [data-annotation-page-marker]`,
+				),
+			).toHaveCount(0);
+		});
+	}
+
 	test("renames, duplicates and bulk-organises documents through the UI", async ({
 		mcp,
 		page,

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@maket/client",
 	"private": true,
-	"version": "1.7.1",
+	"version": "1.7.2",
 	"type": "module",
 	"license": "MIT",
 	"scripts": {

--- a/packages/client/src/store/useStore.test.ts
+++ b/packages/client/src/store/useStore.test.ts
@@ -242,6 +242,70 @@ describe("upsertDoc", () => {
 	});
 });
 
+describe("replaceRenamedDoc", () => {
+	it("replaces the workspace identity while preserving focus, page and reader mode", () => {
+		const oldDoc = makeDoc("old", "report", 3, 0);
+		const otherDoc = makeDoc("other", "report", 1, 0);
+		const renamedDoc = { ...oldDoc, name: "renamed" };
+		useStore.setState({
+			docs: new Map([
+				[oldDoc.name, oldDoc],
+				[otherDoc.name, otherDoc],
+			]),
+			workspaceDocNames: [oldDoc.name, otherDoc.name],
+			focusedDocName: oldDoc.name,
+			focusedPageIndex: 2,
+			workspaceView: "reading",
+			chartesCss: new Map([[oldDoc.name, "/* old */"]]),
+		});
+
+		useStore
+			.getState()
+			.replaceRenamedDoc(
+				oldDoc.name,
+				renamedDoc,
+				[summary("renamed"), summary("other")],
+				"/* renamed */",
+			);
+
+		const state = useStore.getState();
+		expect(state.workspaceDocNames).toEqual(["renamed", "other"]);
+		expect(state.docs.has("old")).toBe(false);
+		expect(state.docs.get("renamed")).toEqual(renamedDoc);
+		expect(state.focusedDocName).toBe("renamed");
+		expect(state.focusedPageIndex).toBe(2);
+		expect(state.workspaceView).toBe("reading");
+		expect(state.chartesCss.has("old")).toBe(false);
+		expect(state.chartesCss.get("renamed")).toBe("/* renamed */");
+	});
+
+	it("does not steal focus from another open document", () => {
+		const oldDoc = makeDoc("old");
+		const otherDoc = makeDoc("other");
+		useStore.setState({
+			docs: new Map([
+				[oldDoc.name, oldDoc],
+				[otherDoc.name, otherDoc],
+			]),
+			workspaceDocNames: [oldDoc.name, otherDoc.name],
+			focusedDocName: otherDoc.name,
+			focusedPageIndex: 0,
+		});
+
+		useStore
+			.getState()
+			.replaceRenamedDoc(
+				oldDoc.name,
+				{ ...oldDoc, name: "renamed" },
+				[summary("renamed"), summary("other")],
+				"",
+			);
+
+		expect(useStore.getState().focusedDocName).toBe("other");
+		expect(useStore.getState().workspaceDocNames).toEqual(["renamed", "other"]);
+	});
+});
+
 describe("workspace / focus", () => {
 	it("removeDocFromWorkspace reassigns focus to the last remaining doc", () => {
 		useStore

--- a/packages/client/src/store/useStore.ts
+++ b/packages/client/src/store/useStore.ts
@@ -117,7 +117,20 @@ interface DocumentStateSlice {
 	clearStatePatches: () => void;
 }
 
-interface AppState extends CollectionSlice, DocumentStateSlice {
+interface DocumentIdentitySlice {
+	replaceRenamedDoc: (
+		oldName: string,
+		doc: Document,
+		docList: DocSummary[],
+		charteCss: string,
+		documentState?: DocumentStateClientView | null,
+	) => void;
+}
+
+interface AppState
+	extends CollectionSlice,
+		DocumentStateSlice,
+		DocumentIdentitySlice {
 	// Connection
 	connected: boolean;
 
@@ -757,6 +770,49 @@ export const useStore = create<AppState>((set, get) => ({
 				focusedPageIndex,
 				docList,
 				chartesCss,
+			};
+		}),
+
+	replaceRenamedDoc: (oldName, doc, docList, charteCss, documentState) =>
+		set((s) => {
+			const docs = new Map(s.docs);
+			docs.delete(oldName);
+			docs.set(doc.name, doc);
+			const workspaceDocNames = [
+				...new Set(
+					s.workspaceDocNames.map((name) =>
+						name === oldName ? doc.name : name,
+					),
+				),
+			];
+			const focusedDocName =
+				s.focusedDocName === oldName ? doc.name : s.focusedDocName;
+			const focusedPageIndex =
+				s.focusedDocName === oldName
+					? clampPageIndex(doc, s.focusedPageIndex)
+					: s.focusedPageIndex;
+			const chartesCss = new Map(s.chartesCss);
+			chartesCss.delete(oldName);
+			chartesCss.set(doc.name, charteCss);
+			const documentStates = { ...s.documentStates };
+			delete documentStates[oldName];
+			if (documentState) documentStates[doc.name] = documentState;
+			const stateCanvasModes = { ...s.stateCanvasModes };
+			const oldCanvasMode = stateCanvasModes[oldName];
+			delete stateCanvasModes[oldName];
+			if (oldCanvasMode) stateCanvasModes[doc.name] = oldCanvasMode;
+			saveWorkspace(workspaceDocNames);
+			syncWorkspace();
+			if (focusedDocName) saveFocusedDoc(focusedDocName);
+			return {
+				docs,
+				workspaceDocNames,
+				focusedDocName,
+				focusedPageIndex,
+				docList,
+				chartesCss,
+				documentStates,
+				stateCanvasModes,
 			};
 		}),
 

--- a/packages/client/src/store/ws.integration.test.ts
+++ b/packages/client/src/store/ws.integration.test.ts
@@ -744,6 +744,48 @@ describe("workspace command wire format", () => {
 	});
 });
 
+describe("doc_renamed", () => {
+	it("atomically replaces the open identity and preserves local focus", async () => {
+		const { initWs, useStore } = await freshWsModule();
+		initWs();
+		MockWebSocket.last().open();
+		useStore.setState({
+			docs: new Map([
+				["old", doc("old")],
+				["other", doc("other")],
+			]),
+			workspaceDocNames: ["old", "other"],
+			focusedDocName: "old",
+			focusedPageIndex: 0,
+		});
+
+		MockWebSocket.last().emit({
+			type: "doc_renamed",
+			oldName: "old",
+			doc: doc("renamed"),
+			docList: [summary("renamed"), summary("other")],
+			annotations: [
+				{
+					id: "note-1",
+					docName: "renamed",
+					type: "note",
+					text: "Keep me",
+				},
+			],
+			charteCss: "/* renamed */",
+		});
+
+		const state = useStore.getState();
+		expect(state.workspaceDocNames).toEqual(["renamed", "other"]);
+		expect(state.docs.has("old")).toBe(false);
+		expect(state.docs.has("renamed")).toBe(true);
+		expect(state.focusedDocName).toBe("renamed");
+		expect(state.pending).toEqual([
+			expect.objectContaining({ id: "note-1", docName: "renamed" }),
+		]);
+	});
+});
+
 describe("doc_removed", () => {
 	it("removes the named doc from the workspace", async () => {
 		const { initWs, useStore } = await freshWsModule();

--- a/packages/client/src/store/ws.ts
+++ b/packages/client/src/store/ws.ts
@@ -356,6 +356,9 @@ function applyWorkspaceSignal(msg: WorkspaceSignal): void {
 			console.log("[ws] doc_removed:", msg.name);
 			useStore.getState().removeDocFromWorkspace(msg.name);
 			break;
+		case "doc_renamed":
+			applyRenamedDocument(msg);
+			break;
 		case "charte_removed":
 			applyCharteUpdated(msg.name, "");
 			break;
@@ -442,6 +445,32 @@ function applyStateMessage(
 			);
 	}
 	if (pendingLoadDoc === doc.name) pendingLoadDoc = null;
+}
+
+function applyRenamedDocument(
+	msg: Extract<WorkspaceSignal, { type: "doc_renamed" }>,
+): void {
+	const doc = msg.doc as Document;
+	const docList = (msg.docList ?? []) as DocSummary[];
+	if (msg.annotations !== undefined) {
+		useStore.setState({ pending: msg.annotations as PendingMessage[] });
+	}
+	if (msg.collections !== undefined) {
+		useStore.getState().setCollections(msg.collections as Collection[]);
+	}
+	if (msg.collectionCursors !== undefined) {
+		useStore.getState().setCollectionCursors(msg.collectionCursors);
+	}
+	if (msg.charteCss) ensureCharteFonts(msg.charteCss);
+	useStore
+		.getState()
+		.replaceRenamedDoc(
+			msg.oldName,
+			doc,
+			docList,
+			msg.charteCss || "",
+			msg.documentState,
+		);
 }
 
 function applyInitialState(

--- a/packages/server/index.ts
+++ b/packages/server/index.ts
@@ -213,6 +213,24 @@ function broadcastDoc(
 	});
 }
 
+// code-moniker: ignore[smell-feature-envy-local]
+// The server entrypoint is the intentional composition boundary for atomic rename fan-out.
+function broadcastRenamedDoc(oldName: string, docName: string): void {
+	const doc = documents.resolve(docName);
+	if (!doc) return;
+	wsRegistry.broadcast({
+		type: "doc_renamed",
+		oldName,
+		doc: documents.lightView(documentRenderer.render(doc), doc.activePage),
+		documentState: documentRenderer.stateView(doc),
+		docList: documents.list(),
+		collections: collections.loadAll(),
+		collectionCursors: collectionCursors.snapshot(),
+		annotations: pending.all(),
+		charteCss: documents.charteCss(doc),
+	});
+}
+
 const LOAD_EVENTS = ["document:created", "document:loaded"] as const;
 const MUTATION_EVENTS = [
 	"document:saved",
@@ -228,6 +246,9 @@ for (const evt of LOAD_EVENTS) {
 for (const evt of MUTATION_EVENTS) {
 	bus.on(evt, ({ docName }) => broadcastDoc(docName));
 }
+bus.on("document:renamed", ({ oldName, docName }) =>
+	broadcastRenamedDoc(oldName, docName),
+);
 bus.on("document-state:changed", ({ docName, paths, attached }) => {
 	if (attached) {
 		broadcastDoc(docName);

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@maket/server",
-	"version": "1.7.1",
+	"version": "1.7.2",
 	"type": "module",
 	"main": "index.ts",
 	"license": "MIT",

--- a/packages/server/src/services/bus.ts
+++ b/packages/server/src/services/bus.ts
@@ -13,6 +13,7 @@ export interface BusEvents {
 	"document:created": { docName: string };
 	"document:saved": { docName: string };
 	"document:loaded": { docName: string };
+	"document:renamed": { oldName: string; docName: string };
 	"document:focused": { docName: string };
 	"workspace:fit-view": Record<string, never>;
 	"document:deleted": { docName: string };

--- a/packages/server/src/services/collection-cursor.ts
+++ b/packages/server/src/services/collection-cursor.ts
@@ -109,6 +109,7 @@ export function createCollectionCursors({
 	bus.on("collection:deleted", reconcile);
 	bus.on("document:created", reconcile);
 	bus.on("document:loaded", reconcile);
+	bus.on("document:renamed", reconcile);
 	bus.on("document:saved", reconcile);
 	bus.on("document:deleted", reconcile);
 

--- a/packages/server/src/services/ws-handler.test.ts
+++ b/packages/server/src/services/ws-handler.test.ts
@@ -617,7 +617,7 @@ describe("ws-handler — file and document mutations", () => {
 		dispose();
 	});
 
-	it("rename_document succeeds and emits delete + load for the rename", () => {
+	it("rename_document succeeds and emits one atomic rename", () => {
 		const { store, documents, pending, bus, handler, dispose } = fixture();
 		store.saveDoc(makeDoc("old"));
 		documents.loadAll();
@@ -629,11 +629,9 @@ describe("ws-handler — file and document mutations", () => {
 			type: "note",
 			text: "Keep me",
 		});
-		const deleted = vi.fn();
-		const loaded = vi.fn();
+		const renamed = vi.fn();
 		const toast = vi.fn();
-		bus.on("document:deleted", deleted);
-		bus.on("document:loaded", loaded);
+		bus.on("document:renamed", renamed);
 		bus.on("toast", toast);
 
 		handler({ type: "rename_document", name: "old", newName: "new" }, STUB_WS);
@@ -643,8 +641,10 @@ describe("ws-handler — file and document mutations", () => {
 		expect(pending.forDoc("new")).toEqual([
 			expect.objectContaining({ id: "rename-note", docName: "new" }),
 		]);
-		expect(deleted).toHaveBeenCalledWith({ docName: "old" });
-		expect(loaded).toHaveBeenCalledWith({ docName: "new" });
+		expect(renamed).toHaveBeenCalledWith({
+			oldName: "old",
+			docName: "new",
+		});
 		expect(toast).toHaveBeenCalledWith(
 			expect.objectContaining({ text: expect.stringMatching(/old.*new/i) }),
 		);

--- a/packages/server/src/services/ws-handler/document-commands.ts
+++ b/packages/server/src/services/ws-handler/document-commands.ts
@@ -106,8 +106,7 @@ export function handleRenameDocument(
 		return;
 	}
 	ctx.documents.rename(name, newName);
-	ctx.bus.emit("document:deleted", { docName: name });
-	ctx.bus.emit("document:loaded", { docName: newName });
+	ctx.bus.emit("document:renamed", { oldName: name, docName: newName });
 	ctx.bus.emit("toast", {
 		text: `"${name}" → "${newName}"`,
 		level: "success",

--- a/packages/server/src/tools/documents.test.ts
+++ b/packages/server/src/tools/documents.test.ts
@@ -539,8 +539,8 @@ describe("maket_doc — action=rename", () => {
 			text: "Keep me",
 		});
 
-		const loaded = vi.fn();
-		bus.on("document:loaded", loaded);
+		const renamed = vi.fn();
+		bus.on("document:renamed", renamed);
 
 		const tool = createMaketDocTool({
 			bus,
@@ -561,7 +561,7 @@ describe("maket_doc — action=rename", () => {
 		expect(annotations.forDoc("new")).toEqual([
 			expect.objectContaining({ id: "rename-note", docName: "new" }),
 		]);
-		expect(loaded).toHaveBeenCalledWith({ docName: "new" });
+		expect(renamed).toHaveBeenCalledWith({ oldName: "old", docName: "new" });
 		store.close();
 	});
 

--- a/packages/server/src/tools/documents.ts
+++ b/packages/server/src/tools/documents.ts
@@ -452,7 +452,7 @@ function runRename(args: Args, documents: Documents, bus: Bus) {
 		return text(`Document "${args.name}" already exists`, true);
 	const oldName = d.name;
 	documents.rename(oldName, args.name);
-	bus.emit("document:loaded", { docName: args.name });
+	bus.emit("document:renamed", { oldName, docName: args.name });
 	bus.emit("toast", {
 		text: `"${oldName}" → "${args.name}"`,
 		level: "success",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@maket/shared",
-	"version": "1.7.1",
+	"version": "1.7.2",
 	"type": "module",
 	"main": "src/index.ts",
 	"types": "src/index.ts",

--- a/packages/shared/src/ws.ts
+++ b/packages/shared/src/ws.ts
@@ -85,6 +85,21 @@ export interface DocumentRemovedSignal {
 	name: string;
 }
 
+/** Atomically replaces a persistent document identity in each browser.
+ * Clients that display or focus `oldName` must preserve that local position
+ * under the renamed document instead of treating the rename as delete + open. */
+export interface DocumentRenamedSignal {
+	type: "doc_renamed";
+	oldName: string;
+	doc: unknown;
+	docList: unknown[];
+	collections?: unknown[];
+	collectionCursors?: PageCollectionCursor[];
+	charteCss: string;
+	documentState?: DocumentStateClientView | null;
+	annotations?: PendingMessage[];
+}
+
 export interface PendingAcknowledgedSignal {
 	type: "ack_messages";
 	ids: unknown[];
@@ -308,6 +323,7 @@ export type WorkspaceSignal =
 	| CharteUpdatedSignal
 	| CharteRemovedSignal
 	| DocumentRemovedSignal
+	| DocumentRenamedSignal
 	| PendingAcknowledgedSignal
 	| AnnotationsChangedSignal
 	| AnnotationCreateResultSignal

--- a/packages/stdio-bridge/package.json
+++ b/packages/stdio-bridge/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@maket/stdio-bridge",
-	"version": "1.7.1",
+	"version": "1.7.2",
 	"type": "module",
 	"main": "src/index.ts",
 	"bin": {

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.ng-galien/maket",
   "title": "Maket",
   "description": "Compose branded visual documents with live preview, data collections, validation, and PDF export.",
-  "version": "1.7.1",
+  "version": "1.7.2",
   "websiteUrl": "https://ng-galien.github.io/maket/",
   "repository": {
     "url": "https://github.com/ng-galien/maket",
@@ -14,7 +14,7 @@
     {
       "registryType": "npm",
       "identifier": "@ng-galien/maket",
-      "version": "1.7.1",
+      "version": "1.7.2",
       "runtimeHint": "npx",
       "runtimeArguments": [
         {


### PR DESCRIPTION
## Summary

- replace document identities atomically after UI or MCP renames
- preserve each workspace window's focus, active page and Canvas or Reader mode
- keep annotations, document lists, review state and collection cursors synchronized
- cover the regression through Canvas and Reader Playwright scenarios with two documents and two windows
- prepare the patch release `1.7.2` with aligned package metadata and changelog

## Root cause

The MCP rename path announced the renamed document as newly loaded without replacing the previous client-side identity. Persistence and the document list already contained only the new name, while the canvas workspace retained the stale old name and rendered both until reload.

## Validation

- `npm run quality` — 103 test files, 973 tests, zero smell violations
- `npm run test:e2e -w @maket/client -- documents.spec.ts` — 6 passed
- `npm run version:check` — packages, lockfile and registry metadata aligned at `1.7.2`
- `npm run test:package` — installable `1.7.2` tarball, 14 tools, headless Chromium and client configuration validated
- independent read-only review of the complete hotfix and release diff — no findings

Closes #64
