### PR TITLE
fix(rendering): isolate authored page CSS in exports

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,6 +89,9 @@ jobs:
       - name: Install Chromium
         run: npx playwright install --with-deps chromium
 
+      - name: Install PDF rasterizer
+        run: sudo apt-get install --yes poppler-utils
+
       - name: Run browser workflows
         run: npm run test:e2e:coverage
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,17 @@ from the git log since the last tag — paste into `[Unreleased]` and edit.
 
 ## [Unreleased]
 
+## [1.7.3] — 2026-08-14
+
+### Fixed
+
+- Keep authored page selectors isolated from Maket's headless render frames so
+  document thumbnails, print previews, PNG snapshots, and PDF exports preserve
+  the same geometry across page sizes and orientations.
+- Persist canvas format, orientation, and print-safe margin changes before
+  broadcasting them, and advance render revision timestamps for rapid updates
+  so document thumbnails cannot reuse stale dimensions.
+
 ## [1.7.2] — 2026-08-14
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "maket",
-  "version": "1.7.2",
+  "version": "1.7.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "maket",
-      "version": "1.7.2",
+      "version": "1.7.3",
       "license": "MIT",
       "workspaces": [
         "packages/*"
@@ -7995,7 +7995,7 @@
     },
     "packages/client": {
       "name": "@maket/client",
-      "version": "1.7.2",
+      "version": "1.7.3",
       "license": "MIT",
       "dependencies": {
         "@maket/shared": "*",
@@ -8029,7 +8029,7 @@
     },
     "packages/server": {
       "name": "@maket/server",
-      "version": "1.7.2",
+      "version": "1.7.3",
       "license": "MIT",
       "dependencies": {
         "@maket/shared": "*",
@@ -8054,7 +8054,7 @@
     },
     "packages/shared": {
       "name": "@maket/shared",
-      "version": "1.7.2",
+      "version": "1.7.3",
       "license": "MIT",
       "dependencies": {
         "@types/mustache": "^4.2.6",
@@ -8064,7 +8064,7 @@
     },
     "packages/stdio-bridge": {
       "name": "@maket/stdio-bridge",
-      "version": "1.7.2",
+      "version": "1.7.3",
       "license": "MIT",
       "dependencies": {
         "@maket/server": "*",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maket",
-  "version": "1.7.2",
+  "version": "1.7.3",
   "mcpName": "io.github.ng-galien/maket",
   "description": "Visual design tool for AI assistants — compose posters, flyers, labels, social posts with PDF export",
   "license": "MIT",

--- a/packages/client/e2e/exports.spec.ts
+++ b/packages/client/e2e/exports.spec.ts
@@ -40,7 +40,7 @@ test.describe("Preview and PDF export", () => {
 			window.print = () => undefined;
 		});
 		await printPage.goto(`/print?name=${encodeURIComponent(docName)}`);
-		await expect(printPage.locator(".page")).toHaveCount(2);
+		await expect(printPage.locator("maket-render-page")).toHaveCount(2);
 		await expect(printPage.getByText("Export proof cover")).toBeVisible();
 		await expect(printPage.getByText("Export proof details")).toBeVisible();
 

--- a/packages/client/e2e/rendering-surfaces.spec.ts
+++ b/packages/client/e2e/rendering-surfaces.spec.ts
@@ -1,0 +1,614 @@
+import { execFile } from "node:child_process";
+import { mkdir, readFile } from "node:fs/promises";
+import { dirname } from "node:path";
+import { promisify } from "node:util";
+import type { Locator, Page, TestInfo } from "@playwright/test";
+import { expect, openWorkspace, test } from "./workspace-test";
+
+const execFileAsync = promisify(execFile);
+
+interface DocumentSpec {
+	format: "A3" | "A4" | "A5" | "A6";
+	orientation: "portrait" | "landscape";
+	w: number;
+	h: number;
+}
+
+interface PrintMargins {
+	top: number;
+	right: number;
+	bottom: number;
+	left: number;
+}
+
+const A3_LANDSCAPE: DocumentSpec = {
+	format: "A3",
+	orientation: "landscape",
+	w: 420,
+	h: 297,
+};
+const A5_PORTRAIT: DocumentSpec = {
+	format: "A5",
+	orientation: "portrait",
+	w: 148,
+	h: 210,
+};
+
+test.describe("Rendering surface isolation", () => {
+	test("keeps an authored .page aligned in Canvas, Reader, and the direct snapshot", async ({
+		mcp,
+		page,
+	}) => {
+		const docName = "A3 authored page rendering contract";
+		await createAuthoredPage(mcp, docName, A3_LANDSCAPE);
+		await openWorkspace(page);
+		await mcp.call("maket_workspace", {
+			action: "focus",
+			doc: docName,
+			page: 1,
+		});
+
+		await expectAuthoredPageAligned(page, docName);
+		await page
+			.getByRole("button", { name: /Reading view|Vue lecture/i })
+			.click();
+		await expectAuthoredPageAligned(page, docName);
+
+		const snapshot = await mcp.call("maket_preview", {
+			action: "snapshot",
+			doc: docName,
+			page: 1,
+			path: "a3-authored-page-rendering-contract.png",
+		});
+		const image = snapshot.content.find((item) => item.type === "image");
+		if (image?.type !== "image") {
+			throw new Error("maket_preview did not return an image");
+		}
+		const snapshotPage = await page.context().newPage();
+		await snapshotPage.setContent(
+			`<img alt="A3 snapshot" src="data:image/png;base64,${image.data}">`,
+		);
+		const snapshotImage = snapshotPage.getByRole("img", {
+			name: "A3 snapshot",
+		});
+		await expect(snapshotImage).toHaveJSProperty("naturalWidth", 1588);
+		await expect(snapshotImage).toHaveJSProperty("naturalHeight", 1123);
+		expect(await imagePixel(snapshotImage, 0.5, 0.5)).toEqual([26, 54, 93]);
+		expect(
+			await imagePixel(
+				snapshotImage,
+				edgeMarkerRatio(A3_LANDSCAPE.w),
+				edgeMarkerRatio(A3_LANDSCAPE.h),
+			),
+		).toEqual([34, 197, 94]);
+	});
+
+	for (const [name, spec] of [
+		["A3 landscape", A3_LANDSCAPE],
+		["A5 portrait", A5_PORTRAIT],
+	] as const) {
+		test(`keeps an authored .page isolated in ${name} thumbnail and print/PDF`, async ({
+			mcp,
+			page,
+		}, testInfo) => {
+			const docName = `${name} authored page export contract`;
+			await createAuthoredPage(mcp, docName, spec);
+			await expectExportSurfaces(page, mcp, docName, spec, testInfo);
+		});
+	}
+
+	test("preserves every render surface while one document changes size and orientation", async ({
+		mcp,
+		page,
+	}, testInfo) => {
+		test.setTimeout(120_000);
+		const docName = "Evolving page export contract";
+		const stages: Array<{
+			name: string;
+			spec: DocumentSpec;
+			margins: PrintMargins;
+		}> = [
+			{
+				name: "small A6 portrait",
+				spec: { format: "A6", orientation: "portrait", w: 105, h: 148 },
+				margins: { top: 5, right: 6, bottom: 7, left: 8 },
+			},
+			{
+				name: "large A3 landscape",
+				spec: A3_LANDSCAPE,
+				margins: { top: 10, right: 12, bottom: 14, left: 16 },
+			},
+			{
+				name: "A4 portrait",
+				spec: { format: "A4", orientation: "portrait", w: 210, h: 297 },
+				margins: { top: 25, right: 20, bottom: 25, left: 20 },
+			},
+			{
+				name: "A4 landscape",
+				spec: { format: "A4", orientation: "landscape", w: 297, h: 210 },
+				margins: { top: 8, right: 10, bottom: 12, left: 14 },
+			},
+		];
+
+		await createResponsiveAuthoredPage(mcp, docName, stages[0].spec);
+		await openWorkspace(page);
+		await mcp.call("maket_workspace", {
+			action: "focus",
+			doc: docName,
+			page: 1,
+		});
+
+		let previousThumbnailSource: string | null = null;
+		for (const stage of stages) {
+			await mcp.call("maket_canvas", {
+				doc: docName,
+				format: stage.spec.format,
+				orientation: stage.spec.orientation,
+				margins: stage.margins,
+			});
+			previousThumbnailSource = await expectLifecycleStage({
+				page,
+				mcp,
+				docName,
+				stageName: stage.name,
+				spec: stage.spec,
+				margins: stage.margins,
+				previousThumbnailSource,
+				testInfo,
+			});
+		}
+	});
+});
+
+interface McpLike {
+	call(
+		name: string,
+		args: Record<string, unknown>,
+	): Promise<{
+		content: Array<{ type: string; data?: string; mimeType?: string }>;
+	}>;
+	callText(name: string, args: Record<string, unknown>): Promise<string>;
+}
+
+async function createAuthoredPage(
+	mcp: McpLike,
+	docName: string,
+	spec: DocumentSpec,
+): Promise<void> {
+	await mcp.call("maket_doc", {
+		action: "new",
+		doc: docName,
+		format: spec.format,
+		orientation: spec.orientation,
+	});
+	await mcp.call("maket_html", {
+		action: "set",
+		doc: docName,
+		page: 1,
+		html: authoredPageHtml(spec),
+	});
+}
+
+async function createResponsiveAuthoredPage(
+	mcp: McpLike,
+	docName: string,
+	initial: DocumentSpec,
+): Promise<void> {
+	await mcp.call("maket_doc", {
+		action: "new",
+		doc: docName,
+		format: initial.format,
+		orientation: initial.orientation,
+	});
+	await mcp.call("maket_html", {
+		action: "set",
+		doc: docName,
+		page: 1,
+		html: [
+			"<style>",
+			".page { width:100%; height:100%; padding:10mm; overflow:hidden; background:#1a365d; position:relative; }",
+			".page h1 { color:#ffffff; font:700 9mm/1 sans-serif; }",
+			".edge-marker { position:absolute; right:10mm; bottom:10mm; width:12mm; height:12mm; background:#22c55e; }",
+			"</style>",
+			'<main class="page" data-id="authored-page">',
+			'<h1 data-id="title">Evolving rendering contract</h1>',
+			'<div class="edge-marker" data-id="edge-marker"></div>',
+			"</main>",
+		].join(""),
+	});
+}
+
+function authoredPageHtml(spec: DocumentSpec): string {
+	return [
+		"<style>",
+		`.page { width:${spec.w}mm; height:${spec.h}mm; padding:10mm; overflow:hidden; background:#1a365d; position:relative; }`,
+		".page h1 { color:#ffffff; font:700 12mm/1 sans-serif; }",
+		".edge-marker { position:absolute; right:10mm; bottom:10mm; width:12mm; height:12mm; background:#22c55e; }",
+		"</style>",
+		'<main class="page" data-id="authored-page">',
+		`<h1 data-id="title">${spec.format} ${spec.orientation} rendering contract</h1>`,
+		'<div class="edge-marker" data-id="edge-marker"></div>',
+		"</main>",
+	].join("");
+}
+
+async function expectExportSurfaces(
+	page: Page,
+	mcp: McpLike,
+	docName: string,
+	spec: DocumentSpec,
+	testInfo: TestInfo,
+): Promise<void> {
+	await openWorkspace(page);
+	await mcp.call("maket_workspace", {
+		action: "focus",
+		doc: docName,
+		page: 1,
+	});
+
+	await page.getByRole("button", { name: /^documents$/i }).click();
+	const panel = page.getByRole("complementary", { name: /^documents$/i });
+	await panel.getByRole("button", { name: /grid view|vue vignettes/i }).click();
+	const thumbnail = panel.getByRole("img", { name: docName });
+	await expectThumbnailLoaded(thumbnail);
+	expect(await imagePixel(thumbnail, 0.5, 0.5)).toEqual([26, 54, 93]);
+	expect(
+		await imagePixel(
+			thumbnail,
+			edgeMarkerRatio(spec.w),
+			edgeMarkerRatio(spec.h),
+		),
+	).toEqual([34, 197, 94]);
+
+	const printPage = await page.context().newPage();
+	await printPage.addInitScript(() => {
+		window.print = () => undefined;
+	});
+	await printPage.goto(`/print?name=${encodeURIComponent(docName)}`);
+	const geometry = await printPage
+		.locator('[data-id="authored-page"]')
+		.evaluate((node) => {
+			const authored = node.getBoundingClientRect();
+			const frame = node.parentElement?.getBoundingClientRect();
+			if (!frame) throw new Error("Print frame is missing");
+			return {
+				left: authored.left - frame.left,
+				top: authored.top - frame.top,
+				width: authored.width - frame.width,
+				height: authored.height - frame.height,
+			};
+		});
+	expect(Math.abs(geometry.left), "print left edge").toBeLessThan(1);
+	expect(Math.abs(geometry.top), "print top edge").toBeLessThan(1);
+	expect(Math.abs(geometry.width), "print width").toBeLessThan(1);
+	expect(Math.abs(geometry.height), "print height").toBeLessThan(1);
+
+	const pdfResult = await mcp.callText("maket_pdf", {
+		doc: docName,
+		quality: "screen",
+		rows: "preview",
+	});
+	expect(pdfResult).toContain("1 page");
+	const pdfPath = pdfResult.match(/^PDF exported:\s*(.+?)\s+\(/)?.[1];
+	if (!pdfPath) throw new Error(`PDF path is missing for ${docName}`);
+	await expectPdfPixels(page, pdfPath, spec, docName, testInfo);
+}
+
+async function expectLifecycleStage({
+	page,
+	mcp,
+	docName,
+	stageName,
+	spec,
+	margins,
+	previousThumbnailSource,
+	testInfo,
+}: {
+	page: Page;
+	mcp: McpLike;
+	docName: string;
+	stageName: string;
+	spec: DocumentSpec;
+	margins: PrintMargins;
+	previousThumbnailSource: string | null;
+	testInfo: TestInfo;
+}): Promise<string> {
+	await expectCanvasGeometry(page, docName, spec, stageName);
+	await expectMarginGuide(page, docName, margins, stageName);
+	await page.getByRole("button", { name: /Reading view|Vue lecture/i }).click();
+	await expectCanvasGeometry(page, docName, spec, `${stageName} Reader`);
+	await expect(
+		page.locator(`[data-doc="${docName}"] .margin-guide`),
+		`${stageName} Reader hides print guides`,
+	).toHaveCount(0);
+	await page.getByRole("button", { name: /Canvas view|Vue canevas/i }).click();
+
+	const snapshot = await mcp.call("maket_preview", {
+		action: "snapshot",
+		doc: docName,
+		page: 1,
+		path: `lifecycle-${spec.format}-${spec.orientation}.png`,
+	});
+	const image = snapshot.content.find((item) => item.type === "image");
+	if (!image?.data) throw new Error("maket_preview did not return an image");
+	const snapshotPage = await page.context().newPage();
+	await snapshotPage.setContent(
+		`<img alt="${stageName} snapshot" src="data:image/png;base64,${image.data}">`,
+	);
+	const snapshotImage = snapshotPage.getByRole("img", {
+		name: `${stageName} snapshot`,
+	});
+	await expect(snapshotImage).toHaveJSProperty(
+		"naturalWidth",
+		Math.ceil(spec.w * 3.78),
+	);
+	await expect(snapshotImage).toHaveJSProperty(
+		"naturalHeight",
+		Math.ceil(spec.h * 3.78),
+	);
+	expect(await imagePixel(snapshotImage, 0.5, 0.5)).toEqual([26, 54, 93]);
+	expect(
+		await imagePixel(
+			snapshotImage,
+			edgeMarkerRatio(spec.w),
+			edgeMarkerRatio(spec.h),
+		),
+	).toEqual([34, 197, 94]);
+	await snapshotPage.close();
+
+	await page.getByRole("button", { name: /^documents$/i }).click();
+	const panel = page.getByRole("complementary", { name: /^documents$/i });
+	await panel.getByRole("button", { name: /grid view|vue vignettes/i }).click();
+	const thumbnail = panel.getByRole("img", { name: docName });
+	await expectThumbnailLoaded(thumbnail);
+	if (previousThumbnailSource) {
+		await expect
+			.poll(() => thumbnail.getAttribute("src"), {
+				message: `${stageName} thumbnail cache key`,
+			})
+			.not.toBe(previousThumbnailSource);
+	}
+	const thumbnailSource = (await thumbnail.getAttribute("src")) ?? "";
+	await expect(thumbnail).toHaveJSProperty("naturalWidth", 960);
+	await expect(thumbnail).toHaveJSProperty(
+		"naturalHeight",
+		Math.round((spec.h / spec.w) * 480) * 2,
+	);
+	expect(await imagePixel(thumbnail, 0.5, 0.5)).toEqual([26, 54, 93]);
+	expect(
+		await imagePixel(
+			thumbnail,
+			edgeMarkerRatio(spec.w),
+			edgeMarkerRatio(spec.h),
+		),
+	).toEqual([34, 197, 94]);
+	await page
+		.getByRole("button", { name: /Close Documents|Fermer.*documents/i })
+		.click();
+
+	const printPage = await page.context().newPage();
+	await printPage.addInitScript(() => {
+		window.print = () => undefined;
+	});
+	await printPage.goto(`/print?name=${encodeURIComponent(docName)}`);
+	await expectPrintGeometry(printPage, spec, stageName);
+	await expect(
+		printPage.locator(".margin-guide"),
+		`${stageName} print excludes the informational guide`,
+	).toHaveCount(0);
+	await printPage.close();
+
+	const pdfResult = await mcp.callText("maket_pdf", {
+		doc: docName,
+		quality: "screen",
+		rows: "preview",
+	});
+	expect(pdfResult).toContain("1 page");
+	const pdfPath = pdfResult.match(/^PDF exported:\s*(.+?)\s+\(/)?.[1];
+	if (!pdfPath) throw new Error(`PDF path is missing for ${stageName}`);
+	const pdf = await readFile(pdfPath);
+	expect(pdf.subarray(0, 5).toString()).toBe("%PDF-");
+	const mediaBox = pdf
+		.toString("latin1")
+		.match(/\/MediaBox\s*\[\s*0\s+0\s+([\d.]+)\s+([\d.]+)\s*\]/);
+	if (!mediaBox) throw new Error(`PDF MediaBox is missing for ${stageName}`);
+	expect(
+		Math.abs(Number(mediaBox[1]) - (spec.w * 72) / 25.4),
+		`${stageName} PDF width`,
+	).toBeLessThan(1);
+	expect(
+		Math.abs(Number(mediaBox[2]) - (spec.h * 72) / 25.4),
+		`${stageName} PDF height`,
+	).toBeLessThan(1);
+	await expectPdfPixels(page, pdfPath, spec, stageName, testInfo);
+
+	return thumbnailSource;
+}
+
+async function expectPdfPixels(
+	page: Page,
+	pdfPath: string,
+	spec: DocumentSpec,
+	label: string,
+	testInfo: TestInfo,
+): Promise<void> {
+	const prefix = testInfo.outputPath(
+		`pdf-${label.toLowerCase().replace(/[^a-z0-9]+/g, "-")}`,
+	);
+	await mkdir(dirname(prefix), { recursive: true });
+	await execFileAsync("pdftoppm", [
+		"-f",
+		"1",
+		"-l",
+		"1",
+		"-singlefile",
+		"-png",
+		"-r",
+		"96",
+		pdfPath,
+		prefix,
+	]);
+	const raster = await readFile(`${prefix}.png`);
+	const rasterPage = await page.context().newPage();
+	await rasterPage.setContent(
+		`<img alt="${label} PDF raster" src="data:image/png;base64,${raster.toString("base64")}">`,
+	);
+	const image = rasterPage.getByRole("img", { name: `${label} PDF raster` });
+	expect(await imagePixel(image, 0.5, 0.5), `${label} PDF center`).toEqual([
+		26, 54, 93,
+	]);
+	expect(
+		await imagePixel(image, edgeMarkerRatio(spec.w), edgeMarkerRatio(spec.h)),
+		`${label} PDF edge marker`,
+	).toEqual([34, 197, 94]);
+	await rasterPage.close();
+}
+
+async function expectMarginGuide(
+	page: Page,
+	docName: string,
+	margins: PrintMargins,
+	stageName: string,
+): Promise<void> {
+	const guide = page.locator(`[data-doc="${docName}"] .margin-guide`);
+	await expect(guide, `${stageName} print margin guide`).toBeVisible();
+	const measured = await guide.evaluate((node) => {
+		const style = getComputedStyle(node);
+		return {
+			top: Number.parseFloat(style.top),
+			right: Number.parseFloat(style.right),
+			bottom: Number.parseFloat(style.bottom),
+			left: Number.parseFloat(style.left),
+		};
+	});
+	for (const side of ["top", "right", "bottom", "left"] as const) {
+		expect(
+			Math.abs(measured[side] - (margins[side] * 96) / 25.4),
+			`${stageName} ${side} print margin`,
+		).toBeLessThan(0.1);
+	}
+}
+
+async function expectCanvasGeometry(
+	page: Page,
+	docName: string,
+	spec: DocumentSpec,
+	stageName: string,
+): Promise<void> {
+	await expectAuthoredPageAligned(page, docName);
+	const ratio = await page
+		.locator(`[data-doc="${docName}"] .page-canvas`)
+		.getAttribute("style")
+		.then((style) => {
+			if (!style) throw new Error(`${stageName} canvas style is missing`);
+			const width = style.match(/width:\s*([\d.]+)mm/)?.[1];
+			const height = style.match(/height:\s*([\d.]+)mm/)?.[1];
+			if (!width || !height)
+				throw new Error(`${stageName} canvas dimensions are missing`);
+			return Number(width) / Number(height);
+		});
+	expect(ratio, `${stageName} canvas aspect ratio`).toBeCloseTo(
+		spec.w / spec.h,
+		4,
+	);
+}
+
+async function expectPrintGeometry(
+	printPage: Page,
+	spec: DocumentSpec,
+	stageName: string,
+): Promise<void> {
+	const geometry = await printPage
+		.locator('[data-id="authored-page"]')
+		.evaluate((node) => {
+			const authored = node.getBoundingClientRect();
+			const frame = node.parentElement?.getBoundingClientRect();
+			if (!frame) throw new Error("Print frame is missing");
+			return {
+				left: authored.left - frame.left,
+				top: authored.top - frame.top,
+				width: authored.width - frame.width,
+				height: authored.height - frame.height,
+				frameRatio: frame.width / frame.height,
+			};
+		});
+	expect(Math.abs(geometry.left), `${stageName} print left edge`).toBeLessThan(
+		1,
+	);
+	expect(Math.abs(geometry.top), `${stageName} print top edge`).toBeLessThan(1);
+	expect(Math.abs(geometry.width), `${stageName} print width`).toBeLessThan(1);
+	expect(Math.abs(geometry.height), `${stageName} print height`).toBeLessThan(
+		1,
+	);
+	expect(geometry.frameRatio, `${stageName} print aspect ratio`).toBeCloseTo(
+		spec.w / spec.h,
+		4,
+	);
+}
+
+function edgeMarkerRatio(dimensionMm: number): number {
+	return (dimensionMm - 16) / dimensionMm;
+}
+
+async function expectAuthoredPageAligned(
+	page: Page,
+	docName: string,
+): Promise<void> {
+	const authoredPage = page.locator(
+		`[data-doc="${docName}"] [data-id="authored-page"]`,
+	);
+	await expect(authoredPage).toBeVisible();
+	await expect
+		.poll(() =>
+			authoredPage.evaluate((node) => {
+				const authored = node.getBoundingClientRect();
+				const canvas = node.closest(".page-canvas")?.getBoundingClientRect();
+				if (!canvas) throw new Error("Page canvas is missing");
+				return [
+					Math.round(authored.left - canvas.left),
+					Math.round(authored.top - canvas.top),
+					Math.round(authored.width - canvas.width),
+					Math.round(authored.height - canvas.height),
+				];
+			}),
+		)
+		.toEqual([0, 0, 0, 0]);
+}
+
+async function expectThumbnailLoaded(image: Locator): Promise<void> {
+	await expect
+		.poll(() =>
+			image.evaluate(
+				(node: HTMLImageElement) => node.complete && node.naturalWidth > 0,
+			),
+		)
+		.toBe(true);
+}
+
+async function imagePixel(
+	image: Locator,
+	xRatio: number,
+	yRatio: number,
+): Promise<number[]> {
+	return image.evaluate(
+		(node: HTMLImageElement, ratios) => {
+			const canvas = document.createElement("canvas");
+			canvas.width = node.naturalWidth;
+			canvas.height = node.naturalHeight;
+			const context = canvas.getContext("2d");
+			if (!context) throw new Error("Canvas 2D context is unavailable");
+			context.drawImage(node, 0, 0);
+			return Array.from(
+				context
+					.getImageData(
+						Math.floor(canvas.width * ratios.xRatio),
+						Math.floor(canvas.height * ratios.yRatio),
+						1,
+						1,
+					)
+					.data.slice(0, 3),
+			);
+		},
+		{ xRatio, yRatio },
+	);
+}

--- a/packages/client/e2e/rendering-surfaces.spec.ts
+++ b/packages/client/e2e/rendering-surfaces.spec.ts
@@ -137,6 +137,10 @@ test.describe("Rendering surface isolation", () => {
 			doc: docName,
 			page: 1,
 		});
+		const surfacePage = await page.context().newPage();
+		await surfacePage.addInitScript(() => {
+			window.print = () => undefined;
+		});
 
 		let previousThumbnailSource: string | null = null;
 		for (const stage of stages) {
@@ -154,6 +158,7 @@ test.describe("Rendering surface isolation", () => {
 				spec: stage.spec,
 				margins: stage.margins,
 				previousThumbnailSource,
+				surfacePage,
 				testInfo,
 			});
 		}
@@ -291,7 +296,7 @@ async function expectExportSurfaces(
 	expect(pdfResult).toContain("1 page");
 	const pdfPath = pdfResult.match(/^PDF exported:\s*(.+?)\s+\(/)?.[1];
 	if (!pdfPath) throw new Error(`PDF path is missing for ${docName}`);
-	await expectPdfPixels(page, pdfPath, spec, docName, testInfo);
+	await expectPdfPixels(printPage, pdfPath, spec, docName, testInfo);
 }
 
 async function expectLifecycleStage({
@@ -302,6 +307,7 @@ async function expectLifecycleStage({
 	spec,
 	margins,
 	previousThumbnailSource,
+	surfacePage,
 	testInfo,
 }: {
 	page: Page;
@@ -311,6 +317,7 @@ async function expectLifecycleStage({
 	spec: DocumentSpec;
 	margins: PrintMargins;
 	previousThumbnailSource: string | null;
+	surfacePage: Page;
 	testInfo: TestInfo;
 }): Promise<string> {
 	await expectCanvasGeometry(page, docName, spec, stageName);
@@ -331,11 +338,10 @@ async function expectLifecycleStage({
 	});
 	const image = snapshot.content.find((item) => item.type === "image");
 	if (!image?.data) throw new Error("maket_preview did not return an image");
-	const snapshotPage = await page.context().newPage();
-	await snapshotPage.setContent(
+	await surfacePage.setContent(
 		`<img alt="${stageName} snapshot" src="data:image/png;base64,${image.data}">`,
 	);
-	const snapshotImage = snapshotPage.getByRole("img", {
+	const snapshotImage = surfacePage.getByRole("img", {
 		name: `${stageName} snapshot`,
 	});
 	await expect(snapshotImage).toHaveJSProperty(
@@ -354,8 +360,6 @@ async function expectLifecycleStage({
 			edgeMarkerRatio(spec.h),
 		),
 	).toEqual([34, 197, 94]);
-	await snapshotPage.close();
-
 	await page.getByRole("button", { name: /^documents$/i }).click();
 	const panel = page.getByRole("complementary", { name: /^documents$/i });
 	await panel.getByRole("button", { name: /grid view|vue vignettes/i }).click();
@@ -386,17 +390,12 @@ async function expectLifecycleStage({
 		.getByRole("button", { name: /Close Documents|Fermer.*documents/i })
 		.click();
 
-	const printPage = await page.context().newPage();
-	await printPage.addInitScript(() => {
-		window.print = () => undefined;
-	});
-	await printPage.goto(`/print?name=${encodeURIComponent(docName)}`);
-	await expectPrintGeometry(printPage, spec, stageName);
+	await surfacePage.goto(`/print?name=${encodeURIComponent(docName)}`);
+	await expectPrintGeometry(surfacePage, spec, stageName);
 	await expect(
-		printPage.locator(".margin-guide"),
+		surfacePage.locator(".margin-guide"),
 		`${stageName} print excludes the informational guide`,
 	).toHaveCount(0);
-	await printPage.close();
 
 	const pdfResult = await mcp.callText("maket_pdf", {
 		doc: docName,
@@ -420,7 +419,7 @@ async function expectLifecycleStage({
 		Math.abs(Number(mediaBox[2]) - (spec.h * 72) / 25.4),
 		`${stageName} PDF height`,
 	).toBeLessThan(1);
-	await expectPdfPixels(page, pdfPath, spec, stageName, testInfo);
+	await expectPdfPixels(surfacePage, pdfPath, spec, stageName, testInfo);
 
 	return thumbnailSource;
 }
@@ -449,11 +448,10 @@ async function expectPdfPixels(
 		prefix,
 	]);
 	const raster = await readFile(`${prefix}.png`);
-	const rasterPage = await page.context().newPage();
-	await rasterPage.setContent(
+	await page.setContent(
 		`<img alt="${label} PDF raster" src="data:image/png;base64,${raster.toString("base64")}">`,
 	);
-	const image = rasterPage.getByRole("img", { name: `${label} PDF raster` });
+	const image = page.getByRole("img", { name: `${label} PDF raster` });
 	expect(await imagePixel(image, 0.5, 0.5), `${label} PDF center`).toEqual([
 		26, 54, 93,
 	]);
@@ -461,7 +459,6 @@ async function expectPdfPixels(
 		await imagePixel(image, edgeMarkerRatio(spec.w), edgeMarkerRatio(spec.h)),
 		`${label} PDF edge marker`,
 	).toEqual([34, 197, 94]);
-	await rasterPage.close();
 }
 
 async function expectMarginGuide(

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@maket/client",
 	"private": true,
-	"version": "1.7.2",
+	"version": "1.7.3",
 	"type": "module",
 	"license": "MIT",
 	"scripts": {

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@maket/server",
-	"version": "1.7.2",
+	"version": "1.7.3",
 	"type": "module",
 	"main": "index.ts",
 	"license": "MIT",

--- a/packages/server/src/lib/render-surface-html.test.ts
+++ b/packages/server/src/lib/render-surface-html.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from "vitest";
+import {
+	buildRenderSurfaceHtml,
+	RENDER_PAGE_TAG,
+} from "./render-surface-html.js";
+
+const canvas = { w: 420, h: 297, bg: "#123456" };
+const authored =
+	'<style>.page{padding:10mm}</style><main class="page">content</main>';
+
+describe("buildRenderSurfaceHtml", () => {
+	it.each([
+		["snapshot", { kind: "snapshot" } as const],
+		["thumbnail", { kind: "thumbnail", scale: 0.5 } as const],
+		["print", { kind: "print" } as const],
+	])("isolates authored page classes on the %s surface", (_name, surface) => {
+		const html = buildRenderSurfaceHtml({
+			canvas,
+			pageHtmls: [authored],
+			charteCss: "",
+			surface,
+		});
+
+		expect(html).toContain(`<${RENDER_PAGE_TAG}`);
+		expect(html).not.toContain('<div class="page"');
+		expect(html.match(/class="page"/g)).toHaveLength(1);
+		expect(html).toContain("width:420mm;height:297mm");
+	});
+
+	it("keeps print pagination on the private frame", () => {
+		const html = buildRenderSurfaceHtml({
+			canvas,
+			pageHtmls: ["one", "two"],
+			charteCss: "",
+			surface: { kind: "print" },
+		});
+
+		expect(html).toContain("@page { size: 420mm 297mm; margin: 0; }");
+		expect(html.match(/data-maket-render-page=/g)).toHaveLength(2);
+		expect(html).toContain("page-break-before:always");
+	});
+
+	it("keeps informational print-safe margins out of physical PDF geometry", () => {
+		const html = buildRenderSurfaceHtml({
+			canvas: {
+				...canvas,
+				margins: { top: 10, right: 12, bottom: 14, left: 16 },
+			},
+			pageHtmls: [authored],
+			charteCss: "",
+			surface: { kind: "print" },
+		});
+
+		expect(html).toContain("@page { size: 420mm 297mm; margin: 0; }");
+		expect(html).not.toContain("margin-guide");
+	});
+
+	it("applies thumbnail scaling only to the private frame", () => {
+		const html = buildRenderSurfaceHtml({
+			canvas,
+			pageHtmls: [authored],
+			charteCss: "",
+			surface: { kind: "thumbnail", scale: 0.5 },
+		});
+
+		expect(html.match(/transform:scale\(0\.5\)/g)).toHaveLength(1);
+	});
+});

--- a/packages/server/src/lib/render-surface-html.ts
+++ b/packages/server/src/lib/render-surface-html.ts
@@ -1,0 +1,86 @@
+import { escapeCssValue, stripStyleClose } from "./css-escape.js";
+
+export const RENDER_PAGE_TAG = "maket-render-page";
+
+export type RenderSurface =
+	| { kind: "snapshot" }
+	| { kind: "thumbnail"; scale: number }
+	| { kind: "print" };
+
+export interface RenderSurfaceHtmlOptions {
+	canvas: {
+		w: number;
+		h: number;
+		bg?: string;
+		margins?: { top: number; right: number; bottom: number; left: number };
+	};
+	pageHtmls: string[];
+	charteCss: string;
+	surface: RenderSurface;
+}
+
+/**
+ * Compose authored pages inside a Maket-owned custom element.
+ *
+ * Headless surfaces used to create their own generic `.page` wrappers. An
+ * authored `.page` selector could therefore resize, pad, or transform the
+ * internal frame. The custom element and its inline geometry keep the shell
+ * outside ordinary authored class/tag selectors while preserving the exact
+ * same composition contract for snapshot, thumbnail, and print/PDF.
+ */
+export function buildRenderSurfaceHtml({
+	canvas,
+	pageHtmls,
+	charteCss,
+	surface,
+}: RenderSurfaceHtmlOptions): string {
+	const safeCharteCss = stripStyleClose(charteCss);
+	const safeBg = escapeCssValue(canvas.bg || "#ffffff");
+	const print = surface.kind === "print";
+	const pageRule = print
+		? `@page { size: ${canvas.w}mm ${canvas.h}mm; margin: 0; }`
+		: "";
+	const reset = print
+		? "* { box-sizing: border-box; margin: 0; padding: 0; print-color-adjust: exact; -webkit-print-color-adjust: exact; }"
+		: "* { box-sizing: border-box; margin: 0; padding: 0; }";
+	const bodyStyle = print
+		? "margin:0;padding:0"
+		: `margin:0;padding:0;width:100%;height:100%;overflow:hidden;background:${safeBg}`;
+	const scaleStyle =
+		surface.kind === "thumbnail"
+			? `transform:scale(${surface.scale});transform-origin:top left;`
+			: "";
+	const frames = pageHtmls
+		.map((html, index) => {
+			const breakStyle =
+				print && index > 0 ? "break-before:page;page-break-before:always;" : "";
+			const style = [
+				"box-sizing:border-box",
+				"display:block",
+				`width:${canvas.w}mm`,
+				`height:${canvas.h}mm`,
+				`background:${safeBg}`,
+				"position:relative",
+				"overflow:hidden",
+				breakStyle,
+				scaleStyle,
+			]
+				.filter(Boolean)
+				.join(";");
+			return `<${RENDER_PAGE_TAG} data-maket-render-page="${index + 1}" style="${style}">${html}</${RENDER_PAGE_TAG}>`;
+		})
+		.join("\n");
+
+	return `<!DOCTYPE html>
+<html>
+<head>
+<meta charset="UTF-8">
+<style>
+  ${safeCharteCss}
+  ${pageRule}
+  ${reset}
+</style>
+</head>
+<body style="${bodyStyle}">${frames}</body>
+</html>`;
+}

--- a/packages/server/src/routes/export.routes.test.ts
+++ b/packages/server/src/routes/export.routes.test.ts
@@ -670,7 +670,7 @@ describe("export routes — .maket bundle", () => {
 		expect(page.html).toContain('data-maket-bind="state.done"');
 		expect(page.html).not.toContain("data-maket-path");
 		expect(page.html).not.toContain("data-maket-type");
-		expect((html.match(/class="page"/g) ?? []).length).toBe(1);
+		expect((html.match(/<maket-render-page/g) ?? []).length).toBe(1);
 	});
 
 	it("GET /api/export-pdf streams the rendered PDF with the default quality", async () => {

--- a/packages/server/src/services/pdf.test.ts
+++ b/packages/server/src/services/pdf.test.ts
@@ -110,7 +110,7 @@ describe("boxShadowToDropShadow", () => {
 });
 
 describe("buildPrintHtml", () => {
-	it("wraps each page in a .page div and inserts @page size", () => {
+	it("wraps each page in a private render frame and inserts @page size", () => {
 		const doc = makeDoc();
 		const out = buildPrintHtml(
 			doc,
@@ -118,9 +118,9 @@ describe("buildPrintHtml", () => {
 			"",
 		);
 		expect(out).toMatch(/@page \{ size: 210mm 297mm/);
-		expect(out).toMatch(/class="page"/);
+		expect(out).toMatch(/<maket-render-page/);
 		// Second page starts with page-break-before
-		expect(out).toMatch(/page-break-before: always/);
+		expect(out).toMatch(/page-break-before:always/);
 	});
 });
 

--- a/packages/server/src/services/pdf.ts
+++ b/packages/server/src/services/pdf.ts
@@ -20,10 +20,10 @@ import {
 	type CollectionRenderMode,
 	cursorRenderOptions,
 } from "../lib/collection-render.js";
-import { escapeCssValue, stripStyleClose } from "../lib/css-escape.js";
 import { inlineImages } from "../lib/image-inline.js";
 import { installNetworkGuard } from "../lib/page-network-guard.js";
 import { waitForPageStable } from "../lib/page-stable-wait.js";
+import { buildRenderSurfaceHtml } from "../lib/render-surface-html.js";
 import type { Document } from "../types.js";
 import type { AssetsService } from "./assets.js";
 import type { BrowserPool } from "./browser-pool.js";
@@ -234,31 +234,10 @@ export function buildPrintHtml(
 	pageHtmls: string[],
 	charteCss: string,
 ): string {
-	const { w, h, bg } = doc.canvas;
-	const pagesHtml = pageHtmls
-		.map(
-			(html, i) => `
-    <div class="page" ${i > 0 ? 'style="page-break-before: always"' : ""}>
-      ${html}
-    </div>
-  `,
-		)
-		.join("\n");
-
-	const safeBg = escapeCssValue(bg || "#ffffff");
-	const safeCharteCss = stripStyleClose(charteCss);
-	return `<!DOCTYPE html>
-<html>
-<head>
-<meta charset="UTF-8">
-<style>
-  ${safeCharteCss}
-  @page { size: ${w}mm ${h}mm; margin: 0; }
-  * { box-sizing: border-box; margin: 0; padding: 0; print-color-adjust: exact; -webkit-print-color-adjust: exact; }
-  body { margin: 0; padding: 0; }
-  .page { width: ${w}mm; height: ${h}mm; background: ${safeBg}; position: relative; overflow: hidden; }
-</style>
-</head>
-<body>${pagesHtml}</body>
-</html>`;
+	return buildRenderSurfaceHtml({
+		canvas: doc.canvas,
+		pageHtmls,
+		charteCss,
+		surface: { kind: "print" },
+	});
 }

--- a/packages/server/src/services/sqlite-store/document-repository.ts
+++ b/packages/server/src/services/sqlite-store/document-repository.ts
@@ -2,10 +2,14 @@ import crypto from "node:crypto";
 import type { DatabaseSync, StatementSync } from "node:sqlite";
 import type { Document, Page } from "../../types.js";
 import { createDocument } from "../../types.js";
+import {
+	DOCUMENT_NOW_SQL,
+	NEXT_DOCUMENT_UPDATED_AT_SQL,
+} from "./document-timestamp.js";
 
 const DOC_UPSERT_SQL = `
   INSERT INTO documents (name, id, category, data_model, canvas, meta, active_page, next_id, created_at, updated_at)
-  VALUES ($name, $id, $category, $data_model, $canvas, $meta, $active_page, $next_id, datetime('now'), datetime('now'))
+  VALUES ($name, $id, $category, $data_model, $canvas, $meta, $active_page, $next_id, ${DOCUMENT_NOW_SQL}, ${DOCUMENT_NOW_SQL})
   ON CONFLICT(name) DO UPDATE SET
     id          = coalesce(excluded.id, documents.id),
     category    = excluded.category,
@@ -14,7 +18,7 @@ const DOC_UPSERT_SQL = `
     meta        = excluded.meta,
     active_page = excluded.active_page,
     next_id     = excluded.next_id,
-    updated_at  = datetime('now')
+    updated_at  = ${NEXT_DOCUMENT_UPDATED_AT_SQL}
 `;
 
 const PAGE_UPSERT_SQL = `
@@ -163,7 +167,7 @@ function prepareDocumentStatements(db: DatabaseSync): {
 		docSelectOne: db.prepare("SELECT * FROM documents WHERE name = $name"),
 		docDelete: db.prepare("DELETE FROM documents WHERE name = $name"),
 		docRename: db.prepare(
-			"UPDATE documents SET name = $new_name, updated_at = datetime('now') WHERE name = $name",
+			`UPDATE documents SET name = $new_name, updated_at = ${NEXT_DOCUMENT_UPDATED_AT_SQL} WHERE name = $name`,
 		),
 		pageUpsert: db.prepare(PAGE_UPSERT_SQL),
 		pageDeleteByDoc: db.prepare("DELETE FROM pages WHERE doc_name = $doc_name"),

--- a/packages/server/src/services/sqlite-store/document-state-repository.ts
+++ b/packages/server/src/services/sqlite-store/document-state-repository.ts
@@ -4,6 +4,7 @@ import type {
 	DocumentStateRevision,
 	DocumentStateSchema,
 } from "@maket/shared";
+import { NEXT_DOCUMENT_UPDATED_AT_SQL } from "./document-timestamp.js";
 
 export interface StoredDocumentState {
 	documentId: string;
@@ -229,10 +230,10 @@ function prepareStatements(db: DatabaseSync): DocumentStateStatements {
 			"SELECT document_id, revision, schema, data, created_at FROM document_state_revisions WHERE document_id = ? ORDER BY revision DESC",
 		),
 		documentMarkState: db.prepare(
-			"UPDATE documents SET data_model = 'state', updated_at = datetime('now') WHERE id = $document_id",
+			`UPDATE documents SET data_model = 'state', updated_at = ${NEXT_DOCUMENT_UPDATED_AT_SQL} WHERE id = $document_id`,
 		),
 		documentTouch: db.prepare(
-			"UPDATE documents SET updated_at = datetime('now') WHERE id = $document_id",
+			`UPDATE documents SET updated_at = ${NEXT_DOCUMENT_UPDATED_AT_SQL} WHERE id = $document_id`,
 		),
 	};
 }

--- a/packages/server/src/services/sqlite-store/document-timestamp.test.ts
+++ b/packages/server/src/services/sqlite-store/document-timestamp.test.ts
@@ -1,0 +1,68 @@
+import { DatabaseSync } from "node:sqlite";
+import { describe, expect, it } from "vitest";
+import { createDocument } from "../../types.js";
+import { createDocumentRepository } from "./document-repository.js";
+import { createDocumentStateRepository } from "./document-state-repository.js";
+import { initializeSQLiteSchema } from "./schema.js";
+
+const STATE_SCHEMA = {
+	type: "object" as const,
+	properties: { title: { type: "string" as const } },
+	required: ["title"],
+};
+
+describe("document render timestamps", () => {
+	it("advance across every mutation from a legacy second-resolution value", () => {
+		const db = new DatabaseSync(":memory:");
+		initializeSQLiteSchema(db);
+		const documents = createDocumentRepository(db);
+		const states = createDocumentStateRepository(db);
+		const doc = createDocument({
+			name: "legacy timestamp",
+			canvas: {
+				format: "A4",
+				orientation: "portrait",
+				w: 210,
+				h: 297,
+				bg: "#fff",
+			},
+		});
+		documents.saveDoc(doc);
+		db.prepare("UPDATE documents SET updated_at = ? WHERE id = ?").run(
+			"2999-01-01 00:00:00",
+			doc.id,
+		);
+
+		const timestamps = [readTimestamp(db, doc.id)];
+		documents.saveDoc(doc);
+		timestamps.push(readTimestamp(db, doc.id));
+		documents.renameDoc(doc.name, "renamed timestamp");
+		timestamps.push(readTimestamp(db, doc.id));
+		states.initializeDocumentState(doc.id, STATE_SCHEMA, { title: "One" });
+		timestamps.push(readTimestamp(db, doc.id));
+		states.appendDocumentStateRevision(doc.id, 1, { title: "Two" });
+		timestamps.push(readTimestamp(db, doc.id));
+		states.replaceDocumentStateSchema(doc.id, 2, STATE_SCHEMA, {
+			title: "Three",
+		});
+		timestamps.push(readTimestamp(db, doc.id));
+
+		expect(timestamps).toEqual([
+			"2999-01-01 00:00:00",
+			"2999-01-01 00:00:00.001",
+			"2999-01-01 00:00:00.002",
+			"2999-01-01 00:00:00.003",
+			"2999-01-01 00:00:00.004",
+			"2999-01-01 00:00:00.005",
+		]);
+		db.close();
+	});
+});
+
+function readTimestamp(db: DatabaseSync, documentId: string): string {
+	const row = db
+		.prepare("SELECT updated_at FROM documents WHERE id = ?")
+		.get(documentId) as { updated_at: string } | undefined;
+	if (!row) throw new Error(`Document ${documentId} is missing.`);
+	return row.updated_at;
+}

--- a/packages/server/src/services/sqlite-store/document-timestamp.ts
+++ b/packages/server/src/services/sqlite-store/document-timestamp.ts
@@ -1,0 +1,13 @@
+/** Millisecond timestamp used by document summaries and render cache keys. */
+export const DOCUMENT_NOW_SQL = "strftime('%Y-%m-%d %H:%M:%f', 'now')";
+
+/**
+ * Advance a document timestamp even when two mutations land in the same
+ * SQLite clock millisecond. The value remains chronologically sortable and
+ * parseable while also acting as a deterministic render revision token.
+ */
+export const NEXT_DOCUMENT_UPDATED_AT_SQL = `CASE
+  WHEN documents.updated_at >= ${DOCUMENT_NOW_SQL}
+    THEN strftime('%Y-%m-%d %H:%M:%f', documents.updated_at, '+0.001 seconds')
+  ELSE ${DOCUMENT_NOW_SQL}
+END`;

--- a/packages/server/src/services/sqlite-store/schema.ts
+++ b/packages/server/src/services/sqlite-store/schema.ts
@@ -18,7 +18,7 @@ const SCHEMA_SQL = `
     active_page INTEGER NOT NULL DEFAULT 0,
     next_id    INTEGER NOT NULL DEFAULT 1,
     created_at TEXT NOT NULL DEFAULT (datetime('now')),
-    updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+    updated_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%d %H:%M:%f', 'now'))
   );
   CREATE TABLE pages (
     doc_name   TEXT NOT NULL REFERENCES documents(name) ON DELETE CASCADE,

--- a/packages/server/src/services/store.test.ts
+++ b/packages/server/src/services/store.test.ts
@@ -34,6 +34,29 @@ describe("SQLiteStore", () => {
 		store.close();
 	});
 
+	it("advances the document render timestamp across back-to-back saves", () => {
+		const store = createSQLiteStore(":memory:");
+		const doc = makeDoc("rapid-updates");
+		store.saveDoc(doc);
+		const first = store.listTimestamps().get(doc.name);
+
+		doc.canvas = {
+			...doc.canvas,
+			format: "A3",
+			orientation: "landscape",
+			w: 420,
+			h: 297,
+		};
+		store.saveDoc(doc);
+		const second = store.listTimestamps().get(doc.name);
+
+		expect(first).toBeTruthy();
+		expect(second).toBeTruthy();
+		expect(second).not.toBe(first);
+		expect(second && first && second > first).toBe(true);
+		store.close();
+	});
+
 	it("preserves page ids across save and load", () => {
 		const store = createSQLiteStore(":memory:");
 		const d = createDocument({

--- a/packages/server/src/services/thumbnail.test.ts
+++ b/packages/server/src/services/thumbnail.test.ts
@@ -78,11 +78,11 @@ describe("createThumbnailService", () => {
 		expect(Buffer.isBuffer(buf)).toBe(true);
 		expect(snapshot).toHaveBeenCalledOnce();
 		const html = snapshot.mock.calls[0]?.[0] ?? "";
-		// The canvas div is still composed with the doc background, just
+		// The private render frame is still composed with the doc background, just
 		// with no content inside — that's what the DocsTab thumbnail shows
 		// for docs the user just created but hasn't laid out yet.
-		expect(html).toContain('<div class="page"');
-		expect(html).toContain("</div></body>");
+		expect(html).toContain("<maket-render-page");
+		expect(html).toContain("</maket-render-page></body>");
 		cleanup();
 	});
 

--- a/packages/server/src/services/thumbnail.ts
+++ b/packages/server/src/services/thumbnail.ts
@@ -13,10 +13,10 @@
  * (puppeteer access). `opts` exists for test overrides only.
  */
 
-import { escapeCssValue, stripStyleClose } from "../lib/css-escape.js";
 import { inlineImages } from "../lib/image-inline.js";
 import { installNetworkGuard } from "../lib/page-network-guard.js";
 import { waitForPageStable } from "../lib/page-stable-wait.js";
+import { buildRenderSurfaceHtml } from "../lib/render-surface-html.js";
 import type { Document } from "../types.js";
 import type { AssetsService } from "./assets.js";
 import type { BrowserPool } from "./browser-pool.js";
@@ -152,31 +152,17 @@ async function renderThumbnailDocument(ctx: {
 	});
 	const resolved = boxShadowToDropShadow(inlined, shadowVars);
 
-	const safeBg = escapeCssValue(renderedDoc.canvas.bg || "#ffffff");
-	const safeCharteCss = stripStyleClose(charteCss);
-	const fullHtml = `<!DOCTYPE html>
-<html>
-<head>
-<meta charset="UTF-8">
-<style>
-  ${safeCharteCss}
-  * { box-sizing: border-box; margin: 0; padding: 0; }
-  html, body { width: 100%; height: 100%; background: ${safeBg}; overflow: hidden; }
-  .page { width: ${renderedDoc.canvas.w}mm; height: ${renderedDoc.canvas.h}mm; background: ${safeBg}; position: relative; overflow: hidden; transform-origin: top left; }
-</style>
-</head>
-<body><div class="page">${resolved}</div></body>
-</html>`;
-
 	const canvasPxW = Math.round(renderedDoc.canvas.w * MM_TO_PX);
 	const pxH = Math.round(
 		(renderedDoc.canvas.h / renderedDoc.canvas.w) * widthPx,
 	);
 	const scale = widthPx / canvasPxW;
-	const scaledHtml = fullHtml.replace(
-		".page {",
-		`.page { transform: scale(${scale});`,
-	);
+	const scaledHtml = buildRenderSurfaceHtml({
+		canvas: renderedDoc.canvas,
+		pageHtmls: [resolved],
+		charteCss,
+		surface: { kind: "thumbnail", scale },
+	});
 
 	const buf = await snapshot(
 		scaledHtml,

--- a/packages/server/src/tools/canvas.test.ts
+++ b/packages/server/src/tools/canvas.test.ts
@@ -56,7 +56,61 @@ describe("maket_canvas (setup)", () => {
 		expect(d?.canvas.orientation).toBe("landscape");
 		expect(d?.canvas.w).toBe(420);
 		expect(d?.canvas.h).toBe(297);
+		const persisted = store.loadOne("d");
+		expect(persisted?.canvas).toMatchObject({
+			format: "A3",
+			orientation: "landscape",
+			w: 420,
+			h: 297,
+		});
 		expect(listener).toHaveBeenCalledWith({ docName: "d" });
+		store.close();
+	});
+
+	it("restores memory and storage without emitting when persistence fails", async () => {
+		const { store, bus, documents } = fixture();
+		const doc = makeDoc("stateful");
+		const page = doc.pages[0];
+		if (!page) throw new Error("Fixture page missing.");
+		page.html = '<p data-id="title">{{ state.title }}</p>';
+		store.saveDoc(doc);
+		store.initializeDocumentState(
+			doc.id,
+			{
+				type: "object",
+				properties: { title: { type: "string" } },
+				required: ["title"],
+			},
+			{ title: "Safe" },
+		);
+		documents.loadAll();
+		const cached = documents.resolve(doc.name);
+		if (!cached?.pages[0]) throw new Error("Fixture page missing.");
+		cached.pages[0].html = '<p data-id="bad">{{ page.number }}</p>';
+
+		const listener = vi.fn();
+		bus.on("canvas:changed", listener);
+		const tool = createMaketCanvasTool({ documents, bus });
+
+		await expect(
+			tool.handler(
+				{ doc: doc.name, format: "A3", orientation: "landscape" },
+				NO_EXTRA,
+			),
+		).rejects.toThrow(/state namespace/);
+		expect(documents.resolve(doc.name)?.canvas).toMatchObject({
+			format: "A4",
+			orientation: "portrait",
+			w: 210,
+			h: 297,
+		});
+		expect(store.loadOne(doc.name)?.canvas).toMatchObject({
+			format: "A4",
+			orientation: "portrait",
+			w: 210,
+			h: 297,
+		});
+		expect(listener).not.toHaveBeenCalled();
 		store.close();
 	});
 

--- a/packages/server/src/tools/canvas.ts
+++ b/packages/server/src/tools/canvas.ts
@@ -72,6 +72,41 @@ const DESCRIPTION = [
 	"Unspecified fields keep their current value.",
 ].join("\n");
 
+type CanvasArgs = z.infer<typeof MaketCanvasSchema>;
+
+// code-moniker: ignore[smell-feature-envy-local]
+// Canvas setup intentionally coordinates document mutation, persistence, and the post-commit bus notification.
+function runCanvasSetup(
+	args: CanvasArgs,
+	documents: Documents,
+	bus: Bus,
+): ReturnType<typeof text> {
+	const d = documents.resolve(args.doc);
+	if (!d) return text(`Document "${args.doc}" not found`, true);
+	const locked = lockGuard(d);
+	if (locked) return locked;
+	const fmt = args.format || d.canvas.format;
+	const orient = args.orientation || d.canvas.orientation || "portrait";
+	const { w, h } = computeCanvasDims(fmt, orient);
+	d.canvas = {
+		format: fmt,
+		orientation: orient,
+		w,
+		h,
+		bg: args.background || d.canvas.bg,
+		margins: args.margins ?? d.canvas.margins,
+	};
+	documents.persist(d.name);
+	bus.emit("canvas:changed", { docName: d.name });
+	const m = d.canvas.margins;
+	const mDesc = m
+		? `  margins:{t:${m.top} r:${m.right} b:${m.bottom} l:${m.left}}mm`
+		: "";
+	return text(
+		`Canvas: ${fmt} ${orient} (${w}x${h}mm) bg=${d.canvas.bg}${mDesc}`,
+	);
+}
+
 export function createMaketCanvasTool(deps: CanvasDeps): ToolHandler {
 	const { documents, bus } = deps;
 	return {
@@ -82,29 +117,7 @@ export function createMaketCanvasTool(deps: CanvasDeps): ToolHandler {
 		},
 		handler: async (rawArgs) => {
 			const args = MaketCanvasSchema.parse(rawArgs);
-			const d = documents.resolve(args.doc);
-			if (!d) return text(`Document "${args.doc}" not found`, true);
-			const locked = lockGuard(d);
-			if (locked) return locked;
-			const fmt = args.format || d.canvas.format;
-			const orient = args.orientation || d.canvas.orientation || "portrait";
-			const { w, h } = computeCanvasDims(fmt, orient);
-			d.canvas = {
-				format: fmt,
-				orientation: orient,
-				w,
-				h,
-				bg: args.background || d.canvas.bg,
-				margins: args.margins ?? d.canvas.margins,
-			};
-			bus.emit("canvas:changed", { docName: d.name });
-			const m = d.canvas.margins;
-			const mDesc = m
-				? `  margins:{t:${m.top} r:${m.right} b:${m.bottom} l:${m.left}}mm`
-				: "";
-			return text(
-				`Canvas: ${fmt} ${orient} (${w}x${h}mm) bg=${d.canvas.bg}${mDesc}`,
-			);
+			return runCanvasSetup(args, documents, bus);
 		},
 	};
 }

--- a/packages/server/src/tools/preview.ts
+++ b/packages/server/src/tools/preview.ts
@@ -19,10 +19,10 @@ import {
 	CHROMIUM_HEADLESS,
 	shouldDisableSandbox,
 } from "../lib/chromium-sandbox.js";
-import { escapeCssValue, stripStyleClose } from "../lib/css-escape.js";
 import { inlineImages } from "../lib/image-inline.js";
 import { installNetworkGuard } from "../lib/page-network-guard.js";
 import { waitForPageStable } from "../lib/page-stable-wait.js";
+import { buildRenderSurfaceHtml } from "../lib/render-surface-html.js";
 import { resolveSafeOutputPath } from "../lib/safe-output-path.js";
 import type { AssetsService } from "../services/assets.js";
 import type { Config } from "../services/config.js";
@@ -136,14 +136,12 @@ async function runSnapshot(
 		mimeFromExt: (p) => assets.mimeFromExt(p),
 	});
 
-	const charteCss = documents.charteCss(rendered);
-	const safeCharteCss = stripStyleClose(charteCss);
-	const safeBg = escapeCssValue(d.canvas.bg || "#ffffff");
-	const fullHtml = `<!DOCTYPE html><html><head><meta charset="UTF-8"><style>
-  ${safeCharteCss}
-  * { box-sizing: border-box; margin: 0; padding: 0; }
-  body { margin: 0; padding: 0; width: ${w}mm; height: ${h}mm; overflow: hidden; background: ${safeBg}; }
-  </style></head><body>${inlinedHtml}</body></html>`;
+	const fullHtml = buildRenderSurfaceHtml({
+		canvas: rendered.canvas,
+		pageHtmls: [inlinedHtml],
+		charteCss: documents.charteCss(rendered),
+		surface: { kind: "snapshot" },
+	});
 
 	const scale = 3.78;
 	const browser = await puppeteer.launch({

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@maket/shared",
-	"version": "1.7.2",
+	"version": "1.7.3",
 	"type": "module",
 	"main": "src/index.ts",
 	"types": "src/index.ts",

--- a/packages/stdio-bridge/package.json
+++ b/packages/stdio-bridge/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@maket/stdio-bridge",
-	"version": "1.7.2",
+	"version": "1.7.3",
 	"type": "module",
 	"main": "src/index.ts",
 	"bin": {

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.ng-galien/maket",
   "title": "Maket",
   "description": "Compose branded visual documents with live preview, data collections, validation, and PDF export.",
-  "version": "1.7.2",
+  "version": "1.7.3",
   "websiteUrl": "https://ng-galien.github.io/maket/",
   "repository": {
     "url": "https://github.com/ng-galien/maket",
@@ -14,7 +14,7 @@
     {
       "registryType": "npm",
       "identifier": "@ng-galien/maket",
-      "version": "1.7.2",
+      "version": "1.7.3",
       "runtimeHint": "npx",
       "runtimeArguments": [
         {


### PR DESCRIPTION
## Summary

- isolate authored page CSS from Maket-owned snapshot, thumbnail, print, and PDF frames through one shared render-surface composer
- persist canvas changes atomically and use monotonic document render revisions so rapid updates invalidate thumbnails reliably
- cover Canvas, Reader, MCP snapshots, document thumbnails, print, and rasterized PDFs across a full format and orientation lifecycle
- prepare the 1.7.3 hotfix metadata and changelog

## Root cause

The affected document defines an authored `.page` root. Thumbnail and print/PDF rendering also used generic `.page` wrappers, so the document CSS resized, padded, and transformed both the authored page and Maket's internal frame. This caused double scaling, offsets, and clipping even though the canvas itself was valid.

The internal frame is now a Maket-owned custom element shared by every headless rendering surface, removing the selector collision and the parallel composition paths.

## Validation

- `npm run quality` — 105 files and 982 tests passed; lint, typecheck, smell review, coverage, and version alignment passed
- `npm run test:e2e` — 57/57 Chromium workflows passed
- PDF exports rasterized with Poppler and checked for center and edge pixels on A3 landscape, A5 portrait, and an A6/A3/A4 portrait-landscape lifecycle
- independent two-pass review completed with no remaining actionable finding
- `git diff --check origin/main` passed

Closes #66
