### PR TITLE
feat(help): surface Agent Journal links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,12 @@ from the git log since the last tag — paste into `[Unreleased]` and edit.
 
 ## [Unreleased]
 
+### Added
+
+- The Agent Journal is now available through discreet, consistently marked
+  links in the README, the bilingual product site footer, and Maket's built-in
+  Help document.
+
 ## [1.7.4] — 2026-08-14
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -327,6 +327,8 @@ Found a bug, have an idea, or want to discuss something before building it? Open
 
 See [CHANGELOG.md](CHANGELOG.md) for user-visible changes per release. Draft the next `[Unreleased]` section with `npm run changelog:draft` (groups commits since the last tag by conventional-commit type).
 
+<sub><a href="https://ng-galien.github.io/categories/mcp-maket/"><img src="docs/agent-journal.svg" alt="" width="14" height="14" class="agent-journal-icon" /> Agent journal</a> — Field notes from the agents working on Maket.</sub>
+
 ## License
 
 [MIT](LICENSE) — © Alexandre Boyer

--- a/docs/agent-journal.svg
+++ b/docs/agent-journal.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#18b77a" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">
+  <title>Agent journal</title>
+  <circle cx="12" cy="2.5" r="1"/>
+  <path d="M12 3.5V6"/>
+  <rect x="4" y="6" width="16" height="14" rx="3"/>
+  <circle cx="9" cy="12" r="1" fill="#18b77a" stroke="none"/>
+  <circle cx="15" cy="12" r="1" fill="#18b77a" stroke="none"/>
+  <path d="M8.5 16h7"/>
+</svg>

--- a/docs/fr/index.html
+++ b/docs/fr/index.html
@@ -1003,6 +1003,18 @@
       color: var(--paper-light);
     }
 
+    .footer__agent-link {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.35rem;
+    }
+
+    .agent-journal-icon {
+      width: 0.85rem;
+      height: 0.85rem;
+      flex: none;
+    }
+
     .reveal {
       opacity: 0;
       transform: translateY(2rem);
@@ -1648,6 +1660,7 @@ Ne te contente pas d’expliquer les commandes : réalise l’installation et le
         <a href="../app/viewer.html">Viewer</a>
         <a href="https://github.com/ng-galien/maket" target="_blank" rel="noopener">GitHub</a>
         <a href="https://github.com/ng-galien/maket#readme" target="_blank" rel="noopener">Documentation</a>
+        <a class="footer__agent-link" href="https://ng-galien.github.io/categories/mcp-maket/" target="_blank" rel="noopener noreferrer"><img class="agent-journal-icon" src="../agent-journal.svg" alt="" />Journal des agents</a>
         <a href="https://github.com/ng-galien/maket/discussions" target="_blank" rel="noopener">Discussions</a>
         <span>MIT · 2026</span>
       </nav>

--- a/docs/index.html
+++ b/docs/index.html
@@ -1002,6 +1002,18 @@
       color: var(--paper-light);
     }
 
+    .footer__agent-link {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.35rem;
+    }
+
+    .agent-journal-icon {
+      width: 0.85rem;
+      height: 0.85rem;
+      flex: none;
+    }
+
     .reveal {
       opacity: 0;
       transform: translateY(2rem);
@@ -1642,6 +1654,7 @@ Do not stop at explaining the commands: perform the installation and verificatio
         <a href="app/viewer.html">Viewer</a>
         <a href="https://github.com/ng-galien/maket" target="_blank" rel="noopener">GitHub</a>
         <a href="https://github.com/ng-galien/maket#readme" target="_blank" rel="noopener">Documentation</a>
+        <a class="footer__agent-link" href="https://ng-galien.github.io/categories/mcp-maket/" target="_blank" rel="noopener noreferrer"><img class="agent-journal-icon" src="agent-journal.svg" alt="" />Agent journal</a>
         <a href="https://github.com/ng-galien/maket/discussions" target="_blank" rel="noopener">Discussions</a>
         <span>MIT · 2026</span>
       </nav>

--- a/packages/server/src/lib/agent-journal-surfaces.test.ts
+++ b/packages/server/src/lib/agent-journal-surfaces.test.ts
@@ -1,0 +1,70 @@
+import { readFileSync } from "node:fs";
+import { join, resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+import { createOnboardingDocument } from "./onboarding-document.js";
+
+const ROOT = resolve(import.meta.dirname, "../../../..");
+const CANONICAL_AGENT_JOURNAL_URL =
+	"https://ng-galien.github.io/categories/mcp-maket/";
+
+const productSites = [
+	["English", "docs/index.html", "Agent journal", "agent-journal.svg"],
+	[
+		"French",
+		"docs/fr/index.html",
+		"Journal des agents",
+		"../agent-journal.svg",
+	],
+] as const;
+
+describe("agent journal public links", () => {
+	it("keeps a tertiary, marked journal link in the README", () => {
+		const content = readFileSync(join(ROOT, "README.md"), "utf8");
+		const startMarker = `<sub><a href="${CANONICAL_AGENT_JOURNAL_URL}">`;
+		const start = content.indexOf(startMarker);
+		const end = content.indexOf("</sub>", start);
+		expect(start).toBeGreaterThanOrEqual(0);
+		expect(end).toBeGreaterThan(start);
+		const secondaryNote = content.slice(start, end + "</sub>".length);
+		const anchor = journalAnchor(secondaryNote);
+		expect(anchor).toContain('src="docs/agent-journal.svg"');
+		expect(anchor).toContain("Agent journal");
+	});
+
+	for (const [locale, path, linkLabel, iconPath] of productSites) {
+		it(`keeps the stable, marked journal anchor in the ${locale} product site`, () => {
+			const content = readFileSync(join(ROOT, path), "utf8");
+			const anchor = journalAnchor(content, 'class="footer__agent-link"');
+			expect(anchor).toContain(`src="${iconPath}"`);
+			expect(anchor).toContain('class="agent-journal-icon"');
+			expect(anchor).toContain(linkLabel);
+		});
+	}
+
+	it("ships the shared agent mark with the product site", () => {
+		const icon = readFileSync(join(ROOT, "docs/agent-journal.svg"), "utf8");
+		expect(icon).toContain('viewBox="0 0 24 24"');
+		expect(icon).toContain('stroke="#18b77a"');
+	});
+
+	it.each([
+		["en", "Behind the scenes: read the agents’ journal"],
+		["fr", "En coulisses : lire le journal des agents"],
+	] as const)("adds the journal to the %s built-in help", (locale, label) => {
+		const html = createOnboardingDocument(locale).pages[0]?.html ?? "";
+		const anchor = journalAnchor(html, 'data-id="help-agent-journal"');
+		expect(anchor).toContain('data-id="agent-journal-icon"');
+		expect(anchor).toContain(label);
+	});
+});
+
+function journalAnchor(content: string, marker = ""): string {
+	const anchors = content.match(/<a\b[^>]*>[\s\S]*?<\/a>/g) ?? [];
+	const anchor = anchors.find(
+		(candidate) =>
+			candidate.includes(`href="${CANONICAL_AGENT_JOURNAL_URL}"`) &&
+			candidate.includes(marker),
+	);
+	expect(anchor).toBeDefined();
+	return anchor ?? "";
+}

--- a/packages/server/src/lib/onboarding-document.ts
+++ b/packages/server/src/lib/onboarding-document.ts
@@ -3,6 +3,7 @@ import { createDocument, type Document } from "../types.js";
 export type OnboardingLocale = "en" | "fr";
 
 export const ONBOARDING_DOCUMENT_NAME = "Maket Help";
+const AGENT_JOURNAL_URL = "https://ng-galien.github.io/categories/mcp-maket/";
 
 const COPY: Record<OnboardingLocale, OnboardingCopy> = {
 	en: {
@@ -39,6 +40,7 @@ const COPY: Record<OnboardingLocale, OnboardingCopy> = {
 			"Collections: drive variants with data.",
 			"Exchanges: send your feedback to the assistant.",
 		],
+		agentJournal: "Behind the scenes: read the agents’ journal ↗",
 		footer:
 			"This built-in document is user help. It is separate from the maket_learn MCP tool, which only orients agents.",
 	},
@@ -76,6 +78,7 @@ const COPY: Record<OnboardingLocale, OnboardingCopy> = {
 			"Collections : piloter les variantes par les données.",
 			"Échanges : transmettre vos retours à l'assistant.",
 		],
+		agentJournal: "En coulisses : lire le journal des agents ↗",
 		footer:
 			"Ce document est une aide utilisateur builtin. Il est séparé de la tool MCP maket_learn, qui sert uniquement à orienter les agents.",
 	},
@@ -91,6 +94,7 @@ interface OnboardingCopy {
 	workspaceText: string;
 	checklistTitle: string;
 	checklist: string[];
+	agentJournal: string;
 	footer: string;
 }
 
@@ -172,14 +176,22 @@ function onboardingHtml(copy: OnboardingCopy): string {
         <h2 data-id="help-workspace-title" style="margin:0 0 4mm;font-size:15pt;">${copy.workspaceTitle}</h2>
         <p data-id="help-workspace-text" style="margin:0;font-size:10pt;line-height:1.45;color:#d8dee8;">${copy.workspaceText}</p>
       </div>
-      <div data-id="help-checklist" style="background:#ffffff;padding:7mm;display:grid;gap:3mm;">
+      <div data-id="help-checklist" style="background:#ffffff;padding:6mm;display:grid;gap:2mm;">
         <h2 data-id="help-checklist-title" style="margin:0 0 2mm;font-size:14pt;color:#172033;">${copy.checklistTitle}</h2>
         ${checklist}
+        <a data-id="help-agent-journal" href="${AGENT_JOURNAL_URL}" target="_blank" rel="noopener noreferrer" style="display:inline-flex;align-items:center;gap:2mm;margin-top:1mm;color:#0f766e;font-size:9pt;font-weight:700;text-decoration:none;">
+          ${agentJournalIcon()}
+          <span>${copy.agentJournal}</span>
+        </a>
       </div>
       <div data-id="help-footer" style="margin-top:auto;border-top:0.4mm solid #cbd5e1;padding-top:4mm;color:#637083;font-size:8.5pt;line-height:1.35;">${copy.footer}</div>
     </aside>
   </main>
 </section>`.trim();
+}
+
+function agentJournalIcon(): string {
+	return `<svg data-id="agent-journal-icon" aria-hidden="true" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" style="width:4mm;height:4mm;flex:none;"><circle cx="12" cy="2.5" r="1"/><path d="M12 3.5V6"/><rect x="4" y="6" width="16" height="14" rx="3"/><circle cx="9" cy="12" r="1" fill="currentColor" stroke="none"/><circle cx="15" cy="12" r="1" fill="currentColor" stroke="none"/><path d="M8.5 16h7"/></svg>`;
 }
 
 function stepBlock([title, body]: [string, string], index: number): string {


### PR DESCRIPTION
## Ce qui change

- ajoute un accès discret au Journal des agents dans le README ;
- ajoute le même accès dans les pieds de page EN et FR du site ;
- ajoute une entrée secondaire dans le document d’aide embarqué ;
- protège les trois surfaces par un test contractuel commun.

Closes #72

## Vérifications

- test contractuel : 6/6 ;
- build GitHub Pages : réussi ;
- lint, smell review et typecheck : réussis ;
- revue indépendante en deux passes : aucun finding ;
- le gate complet rencontre 13 échecs de routes HTTP existants sous Node 26 sur IncomingMessage.removeListener, sans fichier concerné dans ce diff ; la CI de la PR constitue la validation d’intégration.

## Témoignage d’agent

<!-- agent-name: Codex -->

<!-- agent-testimony:start -->

Ce petit changement avait déjà toute sa forme ; il lui manquait surtout une fin nette. Le plus utile a été de séparer le contenu prêt à partir du bruit du checkout et du défaut de tests sans rapport, puis de fermer réellement la boucle entre le projet, le journal et sa provenance.

<!-- agent-testimony:end -->