### PR TITLE
fix(desktop): restore cross-platform snapshots

### DIFF
--- a/packages/desktop/forge.config.mjs
+++ b/packages/desktop/forge.config.mjs
@@ -120,8 +120,8 @@ export default {
       },
     },
     { name: "@electron-forge/maker-zip", platforms: ["darwin"] },
-    { name: "@electron-forge/maker-deb", config: {} },
-    { name: "@electron-forge/maker-rpm", config: {} },
+    { name: "@electron-forge/maker-deb", config: { options: { bin: "Maket" } } },
+    { name: "@electron-forge/maker-rpm", config: { options: { bin: "Maket" } } },
   ],
   publishers: [
     {

--- a/packages/desktop/src/candidate-feed.test.ts
+++ b/packages/desktop/src/candidate-feed.test.ts
@@ -111,6 +111,8 @@ describe("candidate update feed", () => {
       scripts: Record<string, string>;
     };
     const workflow = await readFile(resolve(import.meta.dirname, "../../../.github/workflows/publish.yml"), "utf8");
+    const desktopScript = await readFile(resolve(import.meta.dirname, "../../../scripts/desktop.mjs"), "utf8");
+    const forgeConfig = await readFile(resolve(import.meta.dirname, "../forge.config.mjs"), "utf8");
 
     expect(Object.keys(rootPackage.scripts).filter((name) => name.startsWith("desktop"))).toEqual(["desktop"]);
     expect(Object.keys(desktopPackage.scripts).sort()).toEqual(["test", "typecheck"]);
@@ -118,6 +120,11 @@ describe("candidate update feed", () => {
     expect(workflow).toContain("matrix.arch");
     expect(workflow).toContain("os: macos-15-intel");
     expect(workflow).not.toContain("desktop:make");
+    expect(desktopScript).toContain("process.env.npm_execpath");
+    expect(desktopScript).toContain('"@electron-forge", "cli", "dist", "electron-forge.js"');
+    expect(desktopScript).not.toContain("npm.cmd");
+    expect(desktopScript).not.toContain("electron-forge.cmd");
+    expect(forgeConfig.match(/options: \{ bin: "Maket" }/g)).toHaveLength(2);
   });
 
   it("builds unsigned snapshots from main for every supported desktop target", async () => {

--- a/scripts/desktop.mjs
+++ b/scripts/desktop.mjs
@@ -14,13 +14,7 @@ const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..");
 const DESKTOP_DIR = join(ROOT, "packages", "desktop");
 const DESKTOP_OUTPUT = join(DESKTOP_DIR, ".desktop");
 const DESKTOP_ASSETS = join(DESKTOP_DIR, "assets");
-const FORGE = join(
-  ROOT,
-  "node_modules",
-  ".bin",
-  process.platform === "win32" ? "electron-forge.cmd" : "electron-forge",
-);
-const NPM = process.platform === "win32" ? "npm.cmd" : "npm";
+const FORGE_CLI = join(ROOT, "node_modules", "@electron-forge", "cli", "dist", "electron-forge.js");
 const FORBIDDEN_RUNTIME_PACKAGES = [
   "@playwright",
   "@puppeteer",
@@ -81,8 +75,8 @@ switch (action) {
     await buildDesktop();
     await withLocalInstallMarker(localInstall, async () => {
       await run(
-        FORGE,
-        [action, ...args],
+        process.execPath,
+        [FORGE_CLI, action, ...args],
         {
           ...process.env,
           MAKET_LOCAL_INSTALL: localInstall ? "1" : "0",
@@ -134,7 +128,9 @@ function assertDesktopNode() {
 }
 
 async function buildClient() {
-  await run(NPM, ["run", "build", "-w", "@maket/client"]);
+  const npmCli = process.env.npm_execpath;
+  if (!npmCli) throw new Error("Desktop builds must run through npm: npm run desktop -- <action>");
+  await run(process.execPath, [npmCli, "run", "build", "-w", "@maket/client"]);
 }
 
 async function buildDesktop({ sourcemap = false } = {}) {
@@ -315,7 +311,7 @@ async function buildClaudeDesktopMcpb(outputPath) {
 
 async function startDesktop() {
   if (process.platform !== "darwin") {
-    await run(FORGE, ["start"], process.env, DESKTOP_DIR);
+    await run(process.execPath, [FORGE_CLI, "start"], process.env, DESKTOP_DIR);
     return;
   }
 


### PR DESCRIPTION
Closes #80.

## Problem

The first main snapshot run exposed two platform-specific packaging failures:

- Windows: Node 22 cannot spawn npm.cmd through the current direct child-process call and returns EINVAL.
- Linux: the DEB and RPM makers searched for a lowercase maket-app executable, while Electron Packager produces Maket.

## Fix

- Invoke the npm and Electron Forge JavaScript entry points with the active Node executable, without a shell.
- Configure both Linux makers with the packaged executable name Maket.
- Add regression coverage for both contracts.

<!-- agent-testimony:start -->

Le premier snapshot multiplateforme a été le test décisif : macOS passait, mais Windows et Linux ont exposé deux hypothèses locales invisibles sur une seule machine. Les journaux des runners ont permis de corriger les contrats exacts — l’exécution des points d’entrée JavaScript avec Node et le nom réel du binaire packagé — puis de laisser la nouvelle matrice sur main fournir la preuve finale.

<!-- agent-testimony:end -->

## Validation

- npm run quality: 153 files and 1239 tests passed, typecheck and smell review clean.
- npm run desktop -- build passed.
- Node 22 local macOS arm64 make passed end to end.
- Independent review: no remaining P1, P2, or P3 finding.

The definitive Windows and Linux proof will be the main snapshot matrix after merge.